### PR TITLE
Fix #1, Update to dev guide, add table, add CRC output

### DIFF
--- a/fsw/src/sample_app_events.h
+++ b/fsw/src/sample_app_events.h
@@ -18,26 +18,28 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_events.h 
+** File: sample_app_events.h
 **
-** Purpose: 
+** Purpose:
 **  Define SAMPLE App Events IDs
 **
 ** Notes:
-**
 **
 *************************************************************************/
 #ifndef _sample_app_events_h_
 #define _sample_app_events_h_
 
 
-#define SAMPLE_RESERVED_EID              0
-#define SAMPLE_STARTUP_INF_EID           1 
-#define SAMPLE_COMMAND_ERR_EID           2
-#define SAMPLE_COMMANDNOP_INF_EID        3 
-#define SAMPLE_COMMANDRST_INF_EID        4
-#define SAMPLE_INVALID_MSGID_ERR_EID     5 
-#define SAMPLE_LEN_ERR_EID               6 
+#define SAMPLE_RESERVED_EID                   0
+#define SAMPLE_STARTUP_INF_EID                1
+#define SAMPLE_COMMAND_ERR_EID                2
+#define SAMPLE_COMMANDNOP_INF_EID             3
+#define SAMPLE_COMMANDRST_INF_EID             4
+#define SAMPLE_INVALID_MSGID_ERR_EID          5
+#define SAMPLE_LEN_ERR_EID                    6
+#define SAMPLE_PIPE_ERR_EID                   7
+
+#define SAMPLE_EVENT_COUNTS                   7
 
 #endif /* _sample_app_events_h_ */
 

--- a/fsw/src/sample_app_msg.h
+++ b/fsw/src/sample_app_msg.h
@@ -18,9 +18,9 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_msg.h 
+** File: sample_app_msg.h
 **
-** Purpose: 
+** Purpose:
 **  Define SAMPLE App  Messages and info
 **
 ** Notes:
@@ -35,8 +35,10 @@
 */
 #define SAMPLE_APP_NOOP_CC                 0
 #define SAMPLE_APP_RESET_COUNTERS_CC       1
+#define SAMPLE_APP_PROCESS_CC              2
 
 /*************************************************************************/
+
 /*
 ** Type definition (generic "no arguments" command)
 */
@@ -46,20 +48,39 @@ typedef struct
 
 } SAMPLE_NoArgsCmd_t;
 
+/*
+** The following commands all share the "NoArgs" format
+**
+** They are each given their own type name matching the command name, which_open_mode
+** allows them to change independently in the future without changing the prototype
+** of the handler function
+*/
+typedef SAMPLE_NoArgsCmd_t      SAMPLE_Noop_t;
+typedef SAMPLE_NoArgsCmd_t      SAMPLE_ResetCounters_t;
+typedef SAMPLE_NoArgsCmd_t      SAMPLE_Process_t;
+
 /*************************************************************************/
 /*
 ** Type definition (SAMPLE App housekeeping)
 */
-typedef struct 
+typedef struct
 {
     uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
     uint8              sample_command_error_count;
     uint8              sample_command_count;
     uint8              spare[2];
 
-}   OS_PACK sample_hk_tlm_t  ;
+} OS_PACK sample_hk_tlm_t;
 
-#define SAMPLE_APP_HK_TLM_LNGTH   sizeof ( sample_hk_tlm_t )
+/*
+** Table structure
+*/
+typedef struct
+{
+    uint16     Int1;
+    uint16     Int2;
+
+} SampleTable_t;
 
 #endif /* _sample_app_msg_h_ */
 

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -20,7 +20,7 @@
 **
 ** File: sample_app_version.h
 **
-** Purpose: 
+** Purpose:
 **  The Sample Application header file containing version number
 **
 ** Notes:
@@ -30,11 +30,13 @@
 #ifndef _sample_app_version_h_
 #define _sample_app_version_h_
 
-#define SAMPLE_APP_MAJOR_VERSION    1
-#define SAMPLE_APP_MINOR_VERSION    1
-#define SAMPLE_APP_REVISION         0
-#define SAMPLE_APP_MISSION_REV      0
-      
+
+#define SAMPLE_APP_MAJOR_VERSION              1
+#define SAMPLE_APP_MINOR_VERSION              1
+#define SAMPLE_APP_REVISION                   0
+#define SAMPLE_APP_MISSION_REV                0
+
+
 #endif /* _sample_app_version_h_ */
 
 /************************/

--- a/fsw/src/sample_table.c
+++ b/fsw/src/sample_table.c
@@ -1,0 +1,49 @@
+/*
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.6"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+*/
+
+#include "cfe_tbl_filedef.h"  /* Required to obtain the CFE_TBL_FILEDEF macro definition */
+
+/*
+** The following is an example of a data structure the application may have declared
+** as the format of their table.
+*/
+typedef struct
+{
+    uint16     Int1;
+    uint16     Int2;
+
+} SampleTable_t;
+
+/*
+** The following is an example of the declaration statement that defines the desired
+** contents of the table image.
+*/
+SampleTable_t sampleTable = { 1, 2};
+
+/*
+** The macro below identifies:
+**    1) the data structure type to use as the table image format
+**    2) the name of the table to be placed into the cFE Table File Header
+**    3) a brief description of the contents of the file image
+**    4) the desired name of the table image binary file that is cFE compatible
+*/
+CFE_TBL_FILEDEF(sampleTable, SAMPLE_APP.SampleTable, Table Utility Test Table, sample_table.tbl )


### PR DESCRIPTION
**Describe the contribution**
Updated to dev. guide, added sample table, added CRC output

**Testing performed**
Steps taken to test the contribution:
1. Build 
2. Send Ground Command
3. Verify Results

```
EVS Port1 42/1/SAMPLE_APP 3: SAMPLE: NOOP command
EVS Port1 42/1/SAMPLE_APP 4: SAMPLE: RESET command
1980-012-14:03:25.00026 Sample App: Table Value 1: 1  Value 2: 2
1980-012-14:03:25.00161 Sample App: CRC = 0xFFFF9C00
```

output from tblCRCTool:

```
Table File Name:            ../../exe/cpu1/cf/sample_table.tbl
Table Size:                 4 Bytes
Expected TS Validation CRC: 0xFFFF9C00
```

**Expected behavior changes**
no impact to behavior

**System(s) tested on:**
 - Hardware
 - OS: Ubuntu 18.04.03
 - Versions CFS 6.7

**Contributor Info**
Anh Van, NASA Goddard

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
