### PR TITLE
Invoke SAMPLE_Function as part of Process command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(CFE_SAMPLE_APP C)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 
+# Include the public API from sample_lib to demonstrate how
+# to call library-provided functions
+include_directories(${sample_lib_MISSION_DIR}/fsw/public_inc)
+
 aux_source_directory(fsw/src APP_SRC_FILES)
 
 # Create the app module

--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -32,6 +32,9 @@
 #include "sample_app_version.h"
 #include "sample_app.h"
 
+/* The sample_lib module provides the SAMPLE_Function() prototype */
+#include <sample_lib.h>
+
 #include <string.h>
 
 /*
@@ -438,6 +441,9 @@ void  SAMPLE_ProcessCC( const SAMPLE_Process_t *Msg )
                           TblPtr->Int2);
 
     SAMPLE_GetCrc(TableName);
+
+    /* Invoke a function provided by SAMPLE_LIB */
+    SAMPLE_Function();
 
     return;
 


### PR DESCRIPTION
**Describe the contribution**
Fix #23

Adds a call to the `SAMPLE_Function()` provided by sample_lib as part of the example command processing.

This is to demonstrate two things:
- For FSW, it shows that runtime linking is working as expected, not just for functions provided in the core/base (e.g. CFE,OSAL,PSP) but also for dynamically loaded libraries
- For unit test, it provides a use-case for linking with stubs provided by an external library

**Testing performed**
Build with ENABLE_UNIT_TESTS=TRUE, both with SIMULATION=native and for a 32-bit raspberry pi target.
Execute CFE code, and confirm that everything starts normally.  SAMPLE_LIB is loaded first, and SAMPLE_APP is loaded next and no runtime linking issues are reported.

Log snippet:
```
1980-012-14:03:20.25133 ES Startup: Loading shared library: /cf/sample_lib.so
SAMPLE Lib Initialized.  Version 1.1.0.0
1980-012-14:03:20.25164 ES Startup: Loading file: /cf/sample_app.so, APP: SAMPLE_APP
1980-012-14:03:20.25176 ES Startup: SAMPLE_APP loaded and created
EVS Port1 42/1/SAMPLE_APP 1: SAMPLE App Initialized. Version 1.1.1.0
```

Send the "PROCESS_CC` command and confirm that the function is invoked from SAMPLE_LIB:
```
1980-012-14:03:22.10319 Sample App: Table Value 1: 1  Value 2: 2
1980-012-14:03:22.10321 Sample App: CRC: 0xFFFF9C00
SAMPLE_Function called, buffer='SAMPLE DATA'
```

**Expected behavior changes**
The PROCESS_CC command now makes a call into the sample library.

**System(s) tested on:**
Ubuntu 18.04 LTS 64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
