### PR TITLE
Reverse command and error counts

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -352,8 +352,8 @@ void SAMPLE_ReportHousekeeping( const CCSDS_CommandPacket_t *Msg )
     /*
     ** Get command execution counters...
     */
-    Sample_AppData.SAMPLE_HkTelemetryPkt.sample_command_error_count = Sample_AppData.CmdCounter;
-    Sample_AppData.SAMPLE_HkTelemetryPkt.sample_command_count = Sample_AppData.ErrCounter;
+    Sample_AppData.SAMPLE_HkTelemetryPkt.sample_command_error_count = Sample_AppData.ErrCounter;
+    Sample_AppData.SAMPLE_HkTelemetryPkt.sample_command_count = Sample_AppData.CmdCounter;
 
     /*
     ** Send housekeeping telemetry packet...


### PR DESCRIPTION
**Describe the contribution**

Fix #25
Telemetry values were being copied to the telemetry packet backwards.  Trivial fix.

**Testing performed**
Build code using SIMULATION=native and default config.  Send a command to SAMPLE_APP and verify that the command counter, not the error counter, has incremented in the telemetry packet.

**Expected behavior changes**
The command and error counters are correct, not reversed

**System(s) tested on:**
Ubuntu 18.04 LTS, 64 bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

