### PR TITLE
Fix #28: Check return of CFE_TBL_GetAddress

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -426,12 +426,21 @@ void SAMPLE_ResetCounters( const SAMPLE_ResetCounters_t *Msg )
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
 void  SAMPLE_ProcessCC( const SAMPLE_Process_t *Msg )
 {
+    int32 status;
     SampleTable_t *TblPtr;
     const char *TableName = "SAMPLE_APP.SampleTable";
 
     /* Sample Use of Table */
-    CFE_TBL_GetAddress((void *)&TblPtr,
+
+    status = CFE_TBL_GetAddress((void *)&TblPtr,
                         Sample_AppData.TblHandles[0]);
+
+    if (status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Sample App: Fail to get table address: 0x%08lx",
+                (unsigned long)status);
+        return;
+    }
 
     CFE_ES_WriteToSysLog("Sample App: Table Value 1: %d  Value 2: %d",
                           TblPtr->Int1,


### PR DESCRIPTION
**Describe the contribution**

Fix #28.

The code must not dereference the pointer unless the call returned CFE_SUCCESS, otherwise the pointer is not valid.

**Testing performed**
Execute CFE under simulation, send ProcessCC command and ensure no change to nominal behavior

**Expected behavior changes**
No change in the nominal case, where the command operates normally and the table address is valid.

The SAMPLE_ProcessCC function now does not dereference the table pointer in case the CFE_TBL_GetAddress function fails, which is confirmed in the unit test.

**System(s) tested on:**
Ubuntu 18.04 LTS, 64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
