### PR TITLE
Avoid compile warnings due to printf format

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -163,8 +163,8 @@ int32 SAMPLE_AppInit( void )
                               CFE_EVS_BINARY_FILTER);
     if (status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Error Registering Events, RC = 0x%08X\n",
-                             status);
+        CFE_ES_WriteToSysLog("Sample App: Error Registering Events, RC = 0x%08lX\n",
+                             (unsigned long)status);
         return ( status );
     }
 
@@ -184,8 +184,8 @@ int32 SAMPLE_AppInit( void )
                                Sample_AppData.PipeName);
     if (status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Error creating pipe, RC = 0x%08X\n",
-                             status);
+        CFE_ES_WriteToSysLog("Sample App: Error creating pipe, RC = 0x%08lX\n",
+                             (unsigned long)status);
         return ( status );
     }
 
@@ -196,8 +196,8 @@ int32 SAMPLE_AppInit( void )
                               Sample_AppData.SAMPLE_CommandPipe);
     if (status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Error Subscribing to HK request, RC = 0x%08X\n", 
-                             status);
+        CFE_ES_WriteToSysLog("Sample App: Error Subscribing to HK request, RC = 0x%08lX\n",
+                             (unsigned long)status);
         return ( status );
     }
 
@@ -208,8 +208,8 @@ int32 SAMPLE_AppInit( void )
                               Sample_AppData.SAMPLE_CommandPipe);
     if (status != CFE_SUCCESS )
     {
-        CFE_ES_WriteToSysLog("Sample App: Error Subscribing to Command, RC = 0x%08X\n",
-                             status);
+        CFE_ES_WriteToSysLog("Sample App: Error Subscribing to Command, RC = 0x%08lX\n",
+                             (unsigned long)status);
 
         return ( status );
     }
@@ -225,7 +225,7 @@ int32 SAMPLE_AppInit( void )
     if ( status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("Sample App: Error Registering \
-                              Table, RC = 0x%08X\n", status);
+                              Table, RC = 0x%08lX\n", (unsigned long)status);
 
         return ( status );
     }
@@ -524,7 +524,7 @@ void SAMPLE_GetCrc( const char *TableName )
     else
     {
         Crc = TblInfoPtr.Crc;
-        CFE_ES_WriteToSysLog("Sample App: CRC: 0x%08X\n\n", Crc);
+        CFE_ES_WriteToSysLog("Sample App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
     }
 
     return;


### PR DESCRIPTION
**Describe the contribution**

Fix #30

When using printf-style format conversions one must generally cast the argument to the intended type, as it does not happen implicitly with variable-argument functions.

In particular the existing code worked on the default (native) build but generated warnings when building on RTEMS for a 32-bit x86 target.

**Testing performed**
Build for i686 RTEMS and x86-64 (native) and ensure no warnings on either platform

**Expected behavior changes**
None.

**System(s) tested on:**
Ubuntu 18.04 LTS 64-bit build machine, and i686-rtems4.11 cross target.

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
