### PR TITLE
Fix #41, Do not use aux_source_directory in sample build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,8 @@ include_directories(fsw/platform_inc)
 # to call library-provided functions
 include_directories(${sample_lib_MISSION_DIR}/fsw/public_inc)
 
-aux_source_directory(fsw/src APP_SRC_FILES)
-
 # Create the app module
-add_cfe_app(sample_app ${APP_SRC_FILES})
+add_cfe_app(sample_app fsw/src/sample_app.c)
 
 # Add table
 add_cfe_tables(sampleTable fsw/src/sample_table.c)


### PR DESCRIPTION
**Describe the contribution**

Fix #41

Do not use `aux_source_directory` in the build script, but rather list out each file explicitly.  In particular this avoids incorrectly including the `sample_table.c` file in the app build.

**Testing performed**
Build software with `SIMULATION=native ENABLE_UNIT_TESTS=TRUE` and confirm that `sample_table.c` is no longer included within the link of `sample_app.so`.  

Execute CFE and confirm basic normal operation

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 18.04 LTS 64-bit

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
