### PR TITLE
Fix #53, Opaque CFE_SB_MsgId_t values

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -278,7 +278,7 @@ void SAMPLE_ProcessCommandPacket( CFE_SB_MsgPtr_t Msg )
             CFE_EVS_SendEvent(SAMPLE_INVALID_MSGID_ERR_EID,
                               CFE_EVS_EventType_ERROR,
          	              "SAMPLE: invalid command packet,MID = 0x%x",
-                              MsgId);
+                              (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }
 
@@ -488,7 +488,7 @@ bool SAMPLE_VerifyCmdLength( CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength )
         CFE_EVS_SendEvent(SAMPLE_LEN_ERR_EID,
                           CFE_EVS_EventType_ERROR,
                           "Invalid Msg length: ID = 0x%X,  CC = %d, Len = %d, Expected = %d",
-                          MessageID,
+                          (unsigned int)CFE_SB_MsgIdToValue(MessageID),
                           CommandCode,
                           ActualLength,
                           ExpectedLength);

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -275,7 +275,7 @@ void Test_SAMPLE_ProcessCommandPacket(void)
     SAMPLE_ProcessCommandPacket(&TestMsg.Base);
 
     /* invalid message id */
-    TestMsgId = 0;
+    TestMsgId = CFE_SB_INVALID_MSG_ID;
     UT_SetDataBuffer(UT_KEY(CFE_SB_GetMsgId), &TestMsgId,
             sizeof(TestMsgId), false);
     SAMPLE_ProcessCommandPacket(&TestMsg.Base);


### PR DESCRIPTION
**Describe the contribution**
Apply the `CFE_SB_MsgIdToValue()` and `CFE_SB_ValueToMsgId()` routines where compatibility with an integer MsgId is necessary - syslog prints, events, compile-time MID `#define` values.

Fixes #53 

**Testing performed**
Unit test
Execute CFE and sanity-check normal operation - send commands to app using `cmdUtil` and confirm commands are processed normally.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 18.04 LTS, 64-bit

**Additional context**
In future versions of CFE SB the MsgId type might not be a simple integer, so this is one step in the direction of avoiding this assumption in apps.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.