### PR TITLE
Fix #60, incorrect conversion specifier

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -150,8 +150,8 @@ void Test_SAMPLE_AppMain(void)
      * log will show what the incorrect value was.
      */
     UtAssert_True(SAMPLE_AppData.RunStatus == CFE_ES_RunStatus_APP_ERROR,
-            "SAMPLE_AppData.RunStatus (%d) == CFE_ES_RunStatus_APP_ERROR",
-            SAMPLE_AppData.RunStatus);
+            "SAMPLE_AppData.RunStatus (%lu) == CFE_ES_RunStatus_APP_ERROR",
+            (unsigned long)SAMPLE_AppData.RunStatus);
 
 
     /*


### PR DESCRIPTION
**Describe the contribution**
Corrects a format mismatch warning on some platforms.

Fixes #60 

**Testing performed**
Build for i686-rtems4.11 and confirm warning is fixed

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
i686-rtems4.11 cross build

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.