### PR TITLE
Fix #66, Add extended context information to event hook

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -49,16 +49,19 @@ typedef struct
 {
     uint16 ExpectedEvent;
     uint32 MatchCount;
+    const char *ExpectedText;
 } UT_CheckEvent_t;
 
 /*
  * An example hook function to check for a specific event.
  */
 static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
-        uint32 CallCount, const UT_StubContext_t *Context)
+        uint32 CallCount, const UT_StubContext_t *Context, va_list va)
 {
     UT_CheckEvent_t *State = UserObj;
-    uint16 *EventIdPtr;
+    char TestText[CFE_EVS_MAX_MESSAGE_LENGTH];
+    uint16 EventId;
+    const char *Spec;
 
     /*
      * The CFE_EVS_SendEvent stub passes the EventID as the
@@ -66,10 +69,36 @@ static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
      */
     if (Context->ArgCount > 0)
     {
-        EventIdPtr = (uint16*)Context->ArgPtr[0];
-        if (*EventIdPtr == State->ExpectedEvent)
+        EventId = UT_Hook_GetArgValueByName(Context, "EventID", uint16);
+        if (EventId == State->ExpectedEvent)
         {
-            ++State->MatchCount;
+            /*
+             * Example of how to validate the full argument set.
+             * If reference text was supplied, also check against this.
+             *
+             * NOTE: While this can be done, use with discretion - This isn't really
+             * verifying that the FSW code unit generated the correct event text,
+             * rather it is validating what the system snprintf() library function
+             * produces when passed the format string and args.
+             *
+             * __This derived string is not an actual output of the unit under test__
+             */
+            if (State->ExpectedText != NULL)
+            {
+                Spec = UT_Hook_GetArgValueByName(Context, "Spec", const char *);
+                if (Spec != NULL)
+                {
+                    vsnprintf(TestText, sizeof(TestText), Spec, va);
+                    if (strcmp(TestText,State->ExpectedText) == 0)
+                    {
+                        ++State->MatchCount;
+                    }
+                }
+            }
+            else
+            {
+                ++State->MatchCount;
+            }
         }
     }
 
@@ -80,13 +109,13 @@ static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
  * Helper function to set up for event checking
  * This attaches the hook function to CFE_EVS_SendEvent
  */
-static void UT_CheckEvent_Setup(UT_CheckEvent_t *Evt, uint16 ExpectedEvent)
+static void UT_CheckEvent_Setup(UT_CheckEvent_t *Evt, uint16 ExpectedEvent, const char *ExpectedText)
 {
     memset(Evt, 0, sizeof(*Evt));
     Evt->ExpectedEvent = ExpectedEvent;
-    UT_SetHookFunction(UT_KEY(CFE_EVS_SendEvent), UT_CheckEvent_Hook, Evt);
+    Evt->ExpectedText = ExpectedText;
+    UT_SetVaHookFunction(UT_KEY(CFE_EVS_SendEvent), UT_CheckEvent_Hook, Evt);
 }
-
 
 
 
@@ -183,7 +212,7 @@ void Test_SAMPLE_AppMain(void)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_RcvMsg), 1, CFE_SB_PIPE_RD_ERR);
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_PIPE_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_PIPE_ERR_EID, "SAMPLE APP: SB Pipe Read Error, App Will Exit");
 
     /*
      * Invoke again
@@ -258,7 +287,7 @@ void Test_SAMPLE_ProcessCommandPacket(void)
     UT_CheckEvent_t EventTest;
 
     memset(&TestMsg, 0, sizeof(TestMsg));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_INVALID_MSGID_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_INVALID_MSGID_ERR_EID, "SAMPLE: invalid command packet,MID = 0xffff");
 
     /*
      * The CFE_SB_GetMsgId() stub uses a data buffer to hold the
@@ -323,14 +352,14 @@ void Test_SAMPLE_ProcessGroundCommand(void)
     /* test dispatch of NOOP */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetCmdCode), 1, SAMPLE_APP_NOOP_CC);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg.Noop));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID, NULL);
 
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
     /* test dispatch of RESET */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetCmdCode), 1, SAMPLE_APP_RESET_COUNTERS_CC);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg.Reset));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID, NULL);
 
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
@@ -344,7 +373,7 @@ void Test_SAMPLE_ProcessGroundCommand(void)
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
     /* test an invalid CC */
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMAND_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMAND_ERR_EID, "Invalid ground command code: CC = 1000");
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetCmdCode), 1, 1000);
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
@@ -426,7 +455,7 @@ void Test_SAMPLE_NoopCmd(void)
     memset(&TestMsg, 0, sizeof(TestMsg));
 
     /* test dispatch of NOOP */
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID, "SAMPLE: NOOP command  Version 1.1.9.0");
 
     UT_TEST_FUNCTION_RC(SAMPLE_Noop(&TestMsg), CFE_SUCCESS);
 
@@ -449,7 +478,7 @@ void Test_SAMPLE_ResetCounters(void)
 
     memset(&TestMsg, 0, sizeof(TestMsg));
 
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID, "SAMPLE: RESET command");
 
     UT_TEST_FUNCTION_RC(SAMPLE_ResetCounters(&TestMsg), CFE_SUCCESS);
 
@@ -517,7 +546,7 @@ void Test_SAMPLE_VerifyCmdLength(void)
      * test a match case
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_LEN_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_LEN_ERR_EID, "Invalid Msg length: ID = 0xFFFF,  CC = 0, Len = 18, Expected = 8");
 
     SAMPLE_VerifyCmdLength(&TestMsg, sizeof(TestMsg));
 


### PR DESCRIPTION
**Describe the contribution**
Add a string validation to the sample event hook as an example of how to use the context information supplied to the hook to perform this type of validation.

Fixes #66 

**Testing performed**
Execute unit tests and confirm correct operation. all passing.

**Expected behavior changes**
Test cases now compare an expected event string with a string derived from the spec string and arguments that were output by the unit under test.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Depends on prerequisites/related tickets:
- nasa/osal#479
- nasa/cfe#603

These are necessary to pass the full CFE_EVS_SendEvent context through to the hook function.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
