### PR TITLE
Fix #68, remove references to CCSDS types

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -271,7 +271,7 @@ void SAMPLE_ProcessCommandPacket( CFE_SB_MsgPtr_t Msg )
             break;
 
         case SAMPLE_APP_SEND_HK_MID:
-            SAMPLE_ReportHousekeeping((CCSDS_CommandPacket_t *)Msg);
+            SAMPLE_ReportHousekeeping((CFE_SB_CmdHdr_t *)Msg);
             break;
 
         default:
@@ -348,7 +348,7 @@ void SAMPLE_ProcessGroundCommand( CFE_SB_MsgPtr_t Msg )
 /*         telemetry, packetize it and send it to the housekeeping task via   */
 /*         the software bus                                                   */
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
-int32 SAMPLE_ReportHousekeeping( const CCSDS_CommandPacket_t *Msg )
+int32 SAMPLE_ReportHousekeeping( const CFE_SB_CmdHdr_t *Msg )
 {
     int i;
 

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -116,7 +116,7 @@ void  SAMPLE_AppMain(void);
 int32 SAMPLE_AppInit(void);
 void  SAMPLE_ProcessCommandPacket(CFE_SB_MsgPtr_t Msg);
 void  SAMPLE_ProcessGroundCommand(CFE_SB_MsgPtr_t Msg);
-int32 SAMPLE_ReportHousekeeping(const CCSDS_CommandPacket_t *Msg);
+int32 SAMPLE_ReportHousekeeping(const CFE_SB_CmdHdr_t *Msg);
 int32 SAMPLE_ResetCounters(const SAMPLE_ResetCounters_t *Msg);
 int32 SAMPLE_Process(const SAMPLE_Process_t *Msg);
 int32 SAMPLE_Noop(const SAMPLE_Noop_t *Msg);

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -249,7 +249,7 @@ void Test_SAMPLE_ProcessCommandPacket(void)
     union
     {
         CFE_SB_Msg_t Base;
-        CCSDS_CommandPacket_t Cmd;
+        CFE_SB_CmdHdr_t Cmd;
         SAMPLE_Noop_t Noop;
         SAMPLE_ResetCounters_t Reset;
         SAMPLE_Process_t Process;
@@ -302,7 +302,7 @@ void Test_SAMPLE_ProcessGroundCommand(void)
     union
     {
         CFE_SB_Msg_t Base;
-        CCSDS_CommandPacket_t Cmd;
+        CFE_SB_CmdHdr_t Cmd;
         SAMPLE_Noop_t Noop;
         SAMPLE_ResetCounters_t Reset;
         SAMPLE_Process_t Process;
@@ -361,9 +361,9 @@ void Test_SAMPLE_ReportHousekeeping(void)
 {
     /*
      * Test Case For:
-     * void SAMPLE_ReportHousekeeping( const CCSDS_CommandPacket_t *Msg )
+     * void SAMPLE_ReportHousekeeping( const CFE_SB_CmdHdr_t *Msg )
      */
-    CCSDS_CommandPacket_t   CmdMsg;
+    CFE_SB_CmdHdr_t   CmdMsg;
     SAMPLE_HkTlm_t          HkTelemetryMsg;
 
     memset(&CmdMsg, 0, sizeof(CmdMsg));


### PR DESCRIPTION
**Describe the contribution**
Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type. 

Fixes #68

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
