### PR TITLE
Integration Candidate: 2020-05-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,70 @@
 
 This repository contains a sample application (sample_app), which is a framework component of the Core Flight System.
 
-This sample application is a non-flight example application implementation for the cFS Bundle. It is intended to be located in the `apps/sample_app` subdirectory of a cFS Mission Tree.  The Core Flight System is bundled at https://github.com/nasa/cFS (which includes sample_app as a submodule), which includes build and execution instructions.
+This sample application is a non-flight example application implementation for the cFS Bundle. It is intended to be located in the `apps/sample_app` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS> (which includes sample_app as a submodule), which includes build and execution instructions.
 
-sample_app is an example for how to build and link an application in cFS. See also the skeleton_app (https://github.com/nasa/skeleton_app) if you are looking for a bare-bones application to which to add your business logic.
+sample_app is an example for how to build and link an application in cFS. See also the skeleton_app (<https://github.com/nasa/skeleton_app>) if you are looking for a bare-bones application to which to add your business logic.
 
 ## Version History
 
-#### Development Build: 1.1.8
+### Development Build: 1.1.9
+
+- Applies the CFE_SB_MsgIdToValue() and CFE_SB_ValueToMsgId() routines where compatibility with an integer MsgId is necessary - syslog prints, events, compile-time MID #define values.
+- No more format conversion error in RTEMS build
+- See <https://github.com/nasa/sample_app/pull/63>
+
+### Development Build: 1.1.8
+
 - Coverage data from make lcov includes the sample_app code
-- See https://github.com/nasa/sample_app/pull/62
+- See <https://github.com/nasa/sample_app/pull/62>
 
-#### Development Build: 1.1.7
+### Development Build: 1.1.7
+
 - Fix bug where table is not released after being used
-- Minor updates (see https://github.com/nasa/sample_app/pull/52)
+- Minor updates (see <https://github.com/nasa/sample_app/pull/52>)
 
-#### Development Build: 1.1.6
-- Minor updates (see https://github.com/nasa/sample_app/pull/49)
+### Development Build: 1.1.6
 
-#### Development Build: 1.1.5
+- Minor updates (see <https://github.com/nasa/sample_app/pull/49>)
+
+### Development Build: 1.1.5
+
 - Fix to build on RASPBIAN OS
-- Minor updates (see https://github.com/nasa/sample_app/pull/47)
+- Minor updates (see <https://github.com/nasa/sample_app/pull/47>)
 
-#### Development Build: 1.1.4
+### Development Build: 1.1.4
+
 - Fix for a clean build with OMIT_DEPRECATED
-- Minor updates (see https://github.com/nasa/sample_app/pull/44)
+- Minor updates (see <https://github.com/nasa/sample_app/pull/44>)
 
-#### Development Build: 1.1.3
-- Minor updates (see https://github.com/nasa/sample_app/pull/34)
+### Development Build: 1.1.3
 
-#### Development Build: 1.1.2
-- Minor updates (see https://github.com/nasa/sample_app/pull/20)
+- Minor updates (see <https://github.com/nasa/sample_app/pull/34>)
 
-#### Development Build: 1.1.1
-- Minor updates (see https://github.com/nasa/sample_app/pull/15)
+### Development Build: 1.1.2
 
-### ***OFFICIAL RELEASE: 1.1.0***
+- Minor updates (see <https://github.com/nasa/sample_app/pull/20>)
 
-- Minor updates (see https://github.com/nasa/sample_app/pull/11)
+### Development Build: 1.1.1
+
+- Minor updates (see <https://github.com/nasa/sample_app/pull/15>)
+
+### _**OFFICIAL RELEASE: 1.1.0**_
+
+- Minor updates (see <https://github.com/nasa/sample_app/pull/11>)
 - Not backwards compatible with OSAL 4.2.1
 - Released as part of cFE 6.7.0, Apache 2.0
 
-### ***OFFICIAL RELEASE: 1.0.0a***
+### _**OFFICIAL RELEASE: 1.0.0a**_
 
 - Released as part of cFE 6.6.0a, Apache 2.0
 
 ## Known issues
 
-As a sample application, extensive testing is not performed prior to release and only minimal functionality is included.  Note discrepancies likely exist between this application and the example detailed in the application developer guide.
+As a sample application, extensive testing is not performed prior to release and only minimal functionality is included. Note discrepancies likely exist between this application and the example detailed in the application developer guide.
 
 ## Getting Help
 
-For best results, submit issues:questions or issues:help wanted requests at https://github.com/nasa/cFS.
+For best results, submit issues:questions or issues:help wanted requests at <https://github.com/nasa/cFS>.
 
-Official cFS page: http://cfs.gsfc.nasa.gov
+Official cFS page: <http://cfs.gsfc.nasa.gov>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ sample_app is an example for how to build and link an application in cFS. See al
 
 ## Version History
 
+- Test cases now compare an expected event string with a string derived from the spec string and arguments that were output by the unit under test.
+- Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type. 
+- See <https://github.com/nasa/sample_app/pull/71>
+
 ### Development Build: 1.1.9
 
 - Applies the CFE_SB_MsgIdToValue() and CFE_SB_ValueToMsgId() routines where compatibility with an integer MsgId is necessary - syslog prints, events, compile-time MID #define values.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ sample_app is an example for how to build and link an application in cFS. See al
 
 ## Version History
 
+### Development Build: 1.1.10
 - Test cases now compare an expected event string with a string derived from the spec string and arguments that were output by the unit under test.
 - Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type. 
 - See <https://github.com/nasa/sample_app/pull/71>

--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -271,7 +271,7 @@ void SAMPLE_ProcessCommandPacket( CFE_SB_MsgPtr_t Msg )
             break;
 
         case SAMPLE_APP_SEND_HK_MID:
-            SAMPLE_ReportHousekeeping((CCSDS_CommandPacket_t *)Msg);
+            SAMPLE_ReportHousekeeping((CFE_SB_CmdHdr_t *)Msg);
             break;
 
         default:
@@ -348,7 +348,7 @@ void SAMPLE_ProcessGroundCommand( CFE_SB_MsgPtr_t Msg )
 /*         telemetry, packetize it and send it to the housekeeping task via   */
 /*         the software bus                                                   */
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
-int32 SAMPLE_ReportHousekeeping( const CCSDS_CommandPacket_t *Msg )
+int32 SAMPLE_ReportHousekeeping( const CFE_SB_CmdHdr_t *Msg )
 {
     int i;
 

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -116,7 +116,7 @@ void  SAMPLE_AppMain(void);
 int32 SAMPLE_AppInit(void);
 void  SAMPLE_ProcessCommandPacket(CFE_SB_MsgPtr_t Msg);
 void  SAMPLE_ProcessGroundCommand(CFE_SB_MsgPtr_t Msg);
-int32 SAMPLE_ReportHousekeeping(const CCSDS_CommandPacket_t *Msg);
+int32 SAMPLE_ReportHousekeeping(const CFE_SB_CmdHdr_t *Msg);
 int32 SAMPLE_ResetCounters(const SAMPLE_ResetCounters_t *Msg);
 int32 SAMPLE_Process(const SAMPLE_Process_t *Msg);
 int32 SAMPLE_Noop(const SAMPLE_Noop_t *Msg);

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -33,7 +33,7 @@
 
 #define SAMPLE_APP_MAJOR_VERSION              1
 #define SAMPLE_APP_MINOR_VERSION              1
-#define SAMPLE_APP_REVISION                   8
+#define SAMPLE_APP_REVISION                   9
 #define SAMPLE_APP_MISSION_REV                0
 
 

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -33,7 +33,7 @@
 
 #define SAMPLE_APP_MAJOR_VERSION              1
 #define SAMPLE_APP_MINOR_VERSION              1
-#define SAMPLE_APP_REVISION                   9
+#define SAMPLE_APP_REVISION                   10
 #define SAMPLE_APP_MISSION_REV                0
 
 

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -278,7 +278,7 @@ void Test_SAMPLE_ProcessCommandPacket(void)
     union
     {
         CFE_SB_Msg_t Base;
-        CCSDS_CommandPacket_t Cmd;
+        CFE_SB_CmdHdr_t Cmd;
         SAMPLE_Noop_t Noop;
         SAMPLE_ResetCounters_t Reset;
         SAMPLE_Process_t Process;
@@ -331,7 +331,7 @@ void Test_SAMPLE_ProcessGroundCommand(void)
     union
     {
         CFE_SB_Msg_t Base;
-        CCSDS_CommandPacket_t Cmd;
+        CFE_SB_CmdHdr_t Cmd;
         SAMPLE_Noop_t Noop;
         SAMPLE_ResetCounters_t Reset;
         SAMPLE_Process_t Process;
@@ -390,9 +390,9 @@ void Test_SAMPLE_ReportHousekeeping(void)
 {
     /*
      * Test Case For:
-     * void SAMPLE_ReportHousekeeping( const CCSDS_CommandPacket_t *Msg )
+     * void SAMPLE_ReportHousekeeping( const CFE_SB_CmdHdr_t *Msg )
      */
-    CCSDS_CommandPacket_t   CmdMsg;
+    CFE_SB_CmdHdr_t   CmdMsg;
     SAMPLE_HkTlm_t          HkTelemetryMsg;
 
     memset(&CmdMsg, 0, sizeof(CmdMsg));

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -455,7 +455,7 @@ void Test_SAMPLE_NoopCmd(void)
     memset(&TestMsg, 0, sizeof(TestMsg));
 
     /* test dispatch of NOOP */
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID, "SAMPLE: NOOP command  Version 1.1.9.0");
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID, NULL);
 
     UT_TEST_FUNCTION_RC(SAMPLE_Noop(&TestMsg), CFE_SUCCESS);
 

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -376,6 +376,18 @@ void Test_SAMPLE_ReportHousekeeping(void)
     SAMPLE_AppData.ErrCounter = 11;
 
     /*
+     * CFE_SB_InitMsg() needs to be done to set the emulated MsgId and Length.
+     *
+     * The FSW code only does this once during init and relies on it
+     * remaining during the SAMPLE_ReportHousekeeping().  This does
+     * not happen during UT so it must be initialized again here.
+     */
+    CFE_SB_InitMsg(&SAMPLE_AppData.HkBuf.MsgHdr,
+                   SAMPLE_APP_HK_TLM_MID,
+                   sizeof(SAMPLE_AppData.HkBuf),
+                   true);
+
+    /*
      * Set up to "capture" the telemetry message
      */
     UT_SetDataBuffer(UT_KEY(CFE_SB_SendMsg), &HkTelemetryMsg,

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -59,7 +59,7 @@ static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
         uint32 CallCount, const UT_StubContext_t *Context, va_list va)
 {
     UT_CheckEvent_t *State = UserObj;
-    char TestText[CFE_EVS_MAX_MESSAGE_LENGTH];
+    char TestText[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     uint16 EventId;
     const char *Spec;
 

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -49,16 +49,19 @@ typedef struct
 {
     uint16 ExpectedEvent;
     uint32 MatchCount;
+    const char *ExpectedText;
 } UT_CheckEvent_t;
 
 /*
  * An example hook function to check for a specific event.
  */
 static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
-        uint32 CallCount, const UT_StubContext_t *Context)
+        uint32 CallCount, const UT_StubContext_t *Context, va_list va)
 {
     UT_CheckEvent_t *State = UserObj;
-    uint16 *EventIdPtr;
+    char TestText[CFE_EVS_MAX_MESSAGE_LENGTH];
+    uint16 EventId;
+    const char *Spec;
 
     /*
      * The CFE_EVS_SendEvent stub passes the EventID as the
@@ -66,10 +69,36 @@ static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
      */
     if (Context->ArgCount > 0)
     {
-        EventIdPtr = (uint16*)Context->ArgPtr[0];
-        if (*EventIdPtr == State->ExpectedEvent)
+        EventId = UT_Hook_GetArgValueByName(Context, "EventID", uint16);
+        if (EventId == State->ExpectedEvent)
         {
-            ++State->MatchCount;
+            /*
+             * Example of how to validate the full argument set.
+             * If reference text was supplied, also check against this.
+             *
+             * NOTE: While this can be done, use with discretion - This isn't really
+             * verifying that the FSW code unit generated the correct event text,
+             * rather it is validating what the system snprintf() library function
+             * produces when passed the format string and args.
+             *
+             * __This derived string is not an actual output of the unit under test__
+             */
+            if (State->ExpectedText != NULL)
+            {
+                Spec = UT_Hook_GetArgValueByName(Context, "Spec", const char *);
+                if (Spec != NULL)
+                {
+                    vsnprintf(TestText, sizeof(TestText), Spec, va);
+                    if (strcmp(TestText,State->ExpectedText) == 0)
+                    {
+                        ++State->MatchCount;
+                    }
+                }
+            }
+            else
+            {
+                ++State->MatchCount;
+            }
         }
     }
 
@@ -80,13 +109,13 @@ static int32 UT_CheckEvent_Hook(void *UserObj, int32 StubRetcode,
  * Helper function to set up for event checking
  * This attaches the hook function to CFE_EVS_SendEvent
  */
-static void UT_CheckEvent_Setup(UT_CheckEvent_t *Evt, uint16 ExpectedEvent)
+static void UT_CheckEvent_Setup(UT_CheckEvent_t *Evt, uint16 ExpectedEvent, const char *ExpectedText)
 {
     memset(Evt, 0, sizeof(*Evt));
     Evt->ExpectedEvent = ExpectedEvent;
-    UT_SetHookFunction(UT_KEY(CFE_EVS_SendEvent), UT_CheckEvent_Hook, Evt);
+    Evt->ExpectedText = ExpectedText;
+    UT_SetVaHookFunction(UT_KEY(CFE_EVS_SendEvent), UT_CheckEvent_Hook, Evt);
 }
-
 
 
 
@@ -183,7 +212,7 @@ void Test_SAMPLE_AppMain(void)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_RcvMsg), 1, CFE_SB_PIPE_RD_ERR);
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_PIPE_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_PIPE_ERR_EID, "SAMPLE APP: SB Pipe Read Error, App Will Exit");
 
     /*
      * Invoke again
@@ -258,7 +287,7 @@ void Test_SAMPLE_ProcessCommandPacket(void)
     UT_CheckEvent_t EventTest;
 
     memset(&TestMsg, 0, sizeof(TestMsg));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_INVALID_MSGID_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_INVALID_MSGID_ERR_EID, "SAMPLE: invalid command packet,MID = 0xffff");
 
     /*
      * The CFE_SB_GetMsgId() stub uses a data buffer to hold the
@@ -323,14 +352,14 @@ void Test_SAMPLE_ProcessGroundCommand(void)
     /* test dispatch of NOOP */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetCmdCode), 1, SAMPLE_APP_NOOP_CC);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg.Noop));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID, NULL);
 
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
     /* test dispatch of RESET */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetCmdCode), 1, SAMPLE_APP_RESET_COUNTERS_CC);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg.Reset));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID, NULL);
 
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
@@ -344,7 +373,7 @@ void Test_SAMPLE_ProcessGroundCommand(void)
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
     /* test an invalid CC */
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMAND_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMAND_ERR_EID, "Invalid ground command code: CC = 1000");
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetCmdCode), 1, 1000);
     SAMPLE_ProcessGroundCommand(&TestMsg.Base);
 
@@ -426,7 +455,7 @@ void Test_SAMPLE_NoopCmd(void)
     memset(&TestMsg, 0, sizeof(TestMsg));
 
     /* test dispatch of NOOP */
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDNOP_INF_EID, "SAMPLE: NOOP command  Version 1.1.9.0");
 
     UT_TEST_FUNCTION_RC(SAMPLE_Noop(&TestMsg), CFE_SUCCESS);
 
@@ -449,7 +478,7 @@ void Test_SAMPLE_ResetCounters(void)
 
     memset(&TestMsg, 0, sizeof(TestMsg));
 
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_COMMANDRST_INF_EID, "SAMPLE: RESET command");
 
     UT_TEST_FUNCTION_RC(SAMPLE_ResetCounters(&TestMsg), CFE_SUCCESS);
 
@@ -517,7 +546,7 @@ void Test_SAMPLE_VerifyCmdLength(void)
      * test a match case
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_LEN_ERR_EID);
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_LEN_ERR_EID, "Invalid Msg length: ID = 0xFFFF,  CC = 0, Len = 18, Expected = 8");
 
     SAMPLE_VerifyCmdLength(&TestMsg, sizeof(TestMsg));
 


### PR DESCRIPTION
**Describe the contribution**

Fix #66
Fix #68 

**Testing performed**
https://github.com/nasa/cFS/pull/96/checks

**Expected behavior changes**

PR #67 - Test cases now compare an expected event string with a string derived from the spec string and arguments that were output by the unit under test.

PR #69 - Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type. 

**System(s) tested on**
Ubuntu:Bionic

**Additional context**
Part of nasa/cFS#96

**Contributor Info - All information REQUIRED for consideration of pull request**
 Joseph Hickey, Vantage Systems, Inc.
