### PR TITLE
Fix #81, Install unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sample_app is an example for how to build and link an application in cFS. See al
 
 - Minor updates (see <https://github.com/nasa/sample_app/pull/15>)
 
-### _**OFFICIAL RELEASE: 1.1.0**_
+### _**OFFICIAL RELEASE: 1.1.0 - Aquila**_
 
 - Minor updates (see <https://github.com/nasa/sample_app/pull/11>)
 - Not backwards compatible with OSAL 4.2.1

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -67,6 +67,7 @@ foreach(SRCFILE sample_app.c)
     
     # Add it to the set of tests to run as part of "make test"
     add_test(${TESTNAME} ${TESTNAME}-testrunner)
+    install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
     
 endforeach()
 


### PR DESCRIPTION
**Describe the contribution**
Fix #81 
 - Install unit test as part of cmake recipe

**Testing performed**
Normal build with ENABLE_UNIT_TESTS=true, with make install, and ran sample app unit test from install dir (passed)

**Expected behavior changes**
Sample app test runner now shows up in expected  install dir

**System(s) tested on**
 - Hardware: cFS Dev VM
 - OS: Ubuntu 18.04
 - Versions: current bundle development branch

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC