### PR TITLE
Close #80, Add build number and baseline

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -239,11 +239,8 @@ int32 SAMPLE_AppInit( void )
 
     CFE_EVS_SendEvent (SAMPLE_STARTUP_INF_EID,
                        CFE_EVS_EventType_INFORMATION,
-                       "SAMPLE App Initialized. Version %d.%d.%d.%d",
-                       SAMPLE_APP_MAJOR_VERSION,
-                       SAMPLE_APP_MINOR_VERSION,
-                       SAMPLE_APP_REVISION,
-                       SAMPLE_APP_MISSION_REV);
+                       "SAMPLE App Initialized.%s",
+                       SAMPLE_APP_VERSION_STRING);
 
     return ( CFE_SUCCESS );
 
@@ -387,11 +384,7 @@ int32 SAMPLE_Noop( const SAMPLE_Noop_t *Msg )
 
     CFE_EVS_SendEvent(SAMPLE_COMMANDNOP_INF_EID,
                       CFE_EVS_EventType_INFORMATION,
-                      "SAMPLE: NOOP command  Version %d.%d.%d.%d",
-                      SAMPLE_APP_MAJOR_VERSION,
-                      SAMPLE_APP_MINOR_VERSION,
-                      SAMPLE_APP_REVISION,
-                      SAMPLE_APP_MISSION_REV);
+                      "SAMPLE: NOOP command %s", SAMPLE_APP_VERSION);
 
     return CFE_SUCCESS;
 

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -18,26 +18,49 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_version.h
-**
-** Purpose:
-**  The Sample Application header file containing version number
-**
-** Notes:
-**
-**
 *************************************************************************/
-#ifndef _sample_app_version_h_
-#define _sample_app_version_h_
 
+/*! @file sample_app_version.h
+ * @brief Purpose: 
+ * 
+ *  The Sample App header file containing version information
+ * 
+ */
 
-#define SAMPLE_APP_MAJOR_VERSION              1
-#define SAMPLE_APP_MINOR_VERSION              1
-#define SAMPLE_APP_REVISION                   11
-#define SAMPLE_APP_MISSION_REV                0
+#ifndef SAMPLE_APP_VERSION_H
+#define SAMPLE_APP_VERSION_H
 
+/* Development Build Macro Definitions */
 
-#endif /* _sample_app_version_h_ */
+#define SAMPLE_APP_BUILD_NUMBER 64 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_APP_BUILD_BASELINE "v1.1.0" /*!< Development Build: git tag that is the base for the current development */
+
+/* Version Macro Definitions */
+
+#define SAMPLE_APP_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define SAMPLE_APP_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define SAMPLE_APP_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define SAMPLE_APP_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+#define SAMPLE_APP_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
+#define SAMPLE_APP_STR(x)        SAMPLE_APP_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+
+/*! @brief Development Build Version Number. 
+ * @details Baseline git tag + Number of commits since baseline. @n
+ * See @ref cfsversions for format differences between development and release versions.
+ */
+#define SAMPLE_APP_VERSION SAMPLE_APP_BUILD_BASELINE "+dev" SAMPLE_APP_STR(SAMPLE_APP_BUILD_NUMBER) 
+
+/*! @brief Development Build Version String.
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
+ * See @ref cfsversions for format differences between development and release versions. 
+*/          
+#define SAMPLE_APP_VERSION_STRING                                                          \
+    " Sample App Development Build "                                                     \
+    SAMPLE_APP_VERSION                                                                     \
+    ", Last Official Release: v1.1.0"   /* For full support please use this version */
+
+#endif /* SAMPLE_APP_VERSION_H */
 
 /************************/
 /*  End of File Comment */


### PR DESCRIPTION
**Describe the contribution**
Close #80

**Testing performed**
Built bundle and confirmed SAMPLE_APP reports development version.

**Expected behavior changes**
Version report now uses the version string. See excerpt from cfs log:

```
EVS Port1 42/1/SAMPLE_APP 1: SAMPLE App Initialized Sample App Development Build v1.1.0+dev64 Last Official Release: v1.1.0
```

**System(s) tested on**
Ubuntu Docker on Mac OS X

**Additional context**
Add any other context about the contribution here.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC