### PR TITLE
Fix #87, Unit test MID string format now 32bit

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -272,7 +272,7 @@ void Test_SAMPLE_ProcessCommandPacket(void)
     UT_CheckEvent_t EventTest;
 
     memset(&TestMsg, 0, sizeof(TestMsg));
-    UT_CheckEvent_Setup(&EventTest, SAMPLE_INVALID_MSGID_ERR_EID, "SAMPLE: invalid command packet,MID = 0xffff");
+    UT_CheckEvent_Setup(&EventTest, SAMPLE_INVALID_MSGID_ERR_EID, "SAMPLE: invalid command packet,MID = 0xffffffff");
 
     /*
      * The CFE_SB_GetMsgId() stub uses a data buffer to hold the
@@ -497,7 +497,7 @@ void Test_SAMPLE_VerifyCmdLength(void)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_GetTotalMsgLength), 1, sizeof(TestMsg));
     UT_CheckEvent_Setup(&EventTest, SAMPLE_LEN_ERR_EID,
-                        "Invalid Msg length: ID = 0xFFFF,  CC = 0, Len = 18, Expected = 8");
+                        "Invalid Msg length: ID = 0xFFFFFFFF,  CC = 0, Len = 18, Expected = 8");
 
     SAMPLE_VerifyCmdLength(&TestMsg, sizeof(TestMsg));
 


### PR DESCRIPTION
**Describe the contribution**
Fix #87 
With nasa/cfe#880, the format is now consistently 32 bit, fixed event string check to match.

**Testing performed**
Built unit tests with nasa/cfe#880, now passes

**Expected behavior changes**
Unit test pass

**System(s) tested on**
 - Hardware: cFS Dev server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + nasa/cfe#880 + this commit

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC