### PR TITLE
Fix #110, Apply message alignment pattern

### DIFF
--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -81,8 +81,7 @@ typedef struct
     /*
     ** Operational data (not reported in housekeeping)...
     */
-    CFE_SB_PipeId_t    CommandPipe;
-    CFE_MSG_Message_t *MsgPtr;
+    CFE_SB_PipeId_t CommandPipe;
 
     /*
     ** Initialization data (not reported in housekeeping)...
@@ -104,16 +103,16 @@ typedef struct
 */
 void  SAMPLE_APP_Main(void);
 int32 SAMPLE_APP_Init(void);
-void  SAMPLE_APP_ProcessCommandPacket(CFE_MSG_Message_t *MsgPtr);
-void  SAMPLE_APP_ProcessGroundCommand(CFE_MSG_Message_t *MsgPtr);
-int32 SAMPLE_APP_ReportHousekeeping(const CFE_SB_CmdHdr_t *Msg);
-int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCounters_t *Msg);
-int32 SAMPLE_APP_Process(const SAMPLE_APP_Process_t *Msg);
-int32 SAMPLE_APP_Noop(const SAMPLE_APP_Noop_t *Msg);
+void  SAMPLE_APP_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
+void  SAMPLE_APP_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr);
+int32 SAMPLE_APP_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg);
+int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCountersCmd_t *Msg);
+int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg);
+int32 SAMPLE_APP_Noop(const SAMPLE_APP_NoopCmd_t *Msg);
 void  SAMPLE_APP_GetCrc(const char *TableName);
 
 int32 SAMPLE_APP_TblValidationFunc(void *TblData);
 
-bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t ExpectedLength);
+bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
 #endif /* _sample_app_h_ */

--- a/fsw/src/sample_app_msg.h
+++ b/fsw/src/sample_app_msg.h
@@ -44,20 +44,19 @@
 */
 typedef struct
 {
-    uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
-
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 } SAMPLE_APP_NoArgsCmd_t;
 
 /*
 ** The following commands all share the "NoArgs" format
 **
-** They are each given their own type name matching the command name, which_open_mode
+** They are each given their own type name matching the command name, which
 ** allows them to change independently in the future without changing the prototype
 ** of the handler function
 */
-typedef SAMPLE_APP_NoArgsCmd_t SAMPLE_APP_Noop_t;
-typedef SAMPLE_APP_NoArgsCmd_t SAMPLE_APP_ResetCounters_t;
-typedef SAMPLE_APP_NoArgsCmd_t SAMPLE_APP_Process_t;
+typedef SAMPLE_APP_NoArgsCmd_t SAMPLE_APP_NoopCmd_t;
+typedef SAMPLE_APP_NoArgsCmd_t SAMPLE_APP_ResetCountersCmd_t;
+typedef SAMPLE_APP_NoArgsCmd_t SAMPLE_APP_ProcessCmd_t;
 
 /*************************************************************************/
 /*
@@ -73,10 +72,9 @@ typedef struct
 
 typedef struct
 {
-    CFE_SB_TlmHdr_t            TlmHeader;
-    SAMPLE_APP_HkTlm_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
+    SAMPLE_APP_HkTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } SAMPLE_APP_HkTlm_t;
-
 
 #endif /* _sample_app_msg_h_ */
 

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -40,8 +40,8 @@
 
 #define SAMPLE_APP_MAJOR_VERSION 1  /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define SAMPLE_APP_MINOR_VERSION 1  /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define SAMPLE_APP_REVISION      99 /*!< @brief ONLY APPLY for OFFICIAL releases. The value "99" indicates a development version. Revision version number. */ 
-#define SAMPLE_APP_MISSION_REV 0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+#define SAMPLE_APP_REVISION      99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define SAMPLE_APP_MISSION_REV   0  /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
 
 #define SAMPLE_APP_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
 #define SAMPLE_APP_STR(x) \


### PR DESCRIPTION
**Describe the contribution**
Fix #110 

- Replace CFE_SB_RcvMsg with CFE_SB_ReceiveBuffer
- Use CFE_SB_Buffer_t for receiving and casting to command types
- Use CFE_MSG_CommandHeader_t and CFE_MSG_TelemetryHeader_t in
  command and telemetry type definitions
- Use CFE_SB_TransmitMsg to copy the command and telemetry
  into a CFE_SB_Buffer_t and send it where needed
- Avoids need to create send buffers within the app (or union
  the packet types with CFE_SB_Buffer_t)
- Eliminates references to CFE_SB_CmdHdr_t and CFE_SB_TlmHdr_t
  that formerly enforced alignment since these had potential
  to change the actual packet sizes
- No need to cast to CFE_MSG_Message_t anywhere since it's
  available in the CFE_SB_Buffer_t union
- Replaced CFE_MSG_Size_t with size_t

**Testing performed**
Bundle CI, unit tests, spot checked cmd/tlm

**Expected behavior changes**
None, pattern applied only

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle (integration-candidate) + nasa/cFE#1015, and this commit

**Additional context**
Depends on nasa/cFE#1015

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC