### PR TITLE
Fix #115, Refactor UT_ClearForceFail to UT_ClearDefaultReturnValue

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -593,7 +593,7 @@ void Test_SAMPLE_APP_GetCrc(void)
     SAMPLE_APP_GetCrc("UT");
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_ES_WriteToSysLog)) == 1, "CFE_ES_WriteToSysLog() called");
 
-    UT_ClearForceFail(UT_KEY(CFE_TBL_GetInfo));
+    UT_ClearDefaultReturnValue(UT_KEY(CFE_TBL_GetInfo));
     SAMPLE_APP_GetCrc("UT");
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_ES_WriteToSysLog)) == 2, "CFE_ES_WriteToSysLog() called");
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #115  
Rename UT_ClearForceFail to UT_ClearDefaultValue

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Dependant on nasa/osal#725

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
