### PR TITLE
Fix #101, Correct CFE_TBL_GetAddress return code check

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -400,7 +400,7 @@ int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg)
 
     status = CFE_TBL_GetAddress((void *)&TblPtr, SAMPLE_APP_Data.TblHandles[0]);
 
-    if (status != CFE_SUCCESS)
+    if (status < CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Fail to get table address: 0x%08lx", (unsigned long)status);
         return status;


### PR DESCRIPTION
**Describe the contribution**
Fix #101 - only status < CFE_SUCCESS is an error since CFE_TBL_GetAddress has multiple "success" codes

**Testing performed**
Built, ran, sent sample app process command to confirm it works

**Expected behavior changes**
Resolves bug where success code was reported as an error

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC