### PR TITLE
Fix #126, simplify build to use wrappers and interface libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,14 @@
-cmake_minimum_required(VERSION 2.6.4)
 project(CFE_SAMPLE_APP C)
 
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 
-# Include the public API from sample_lib to demonstrate how
-# to call library-provided functions
-include_directories(${sample_lib_MISSION_DIR}/fsw/public_inc)
-
 # Create the app module
 add_cfe_app(sample_app fsw/src/sample_app.c)
+
+# Include the public API from sample_lib to demonstrate how
+# to call library-provided functions
+add_cfe_app_dependency(sample_app sample_lib)
 
 # Add table
 add_cfe_tables(sampleAppTable fsw/tables/sample_app_tbl.c)

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -16,60 +16,28 @@
 # - "coveragetest" contains source code for the actual unit test cases
 #    The primary objective is to get line/path coverage on the FSW 
 #    code units.
-# - "wrappers" contains wrappers for the FSW code.  The wrapper adds
-#    any UT-specific scaffolding to facilitate the coverage test, and
-#    includes the unmodified FSW source file.
 #
  
-set(UT_NAME sample_app)
-
 # Use the UT assert public API, and allow direct
 # inclusion of source files that are normally private
-include_directories(${osal_MISSION_DIR}/ut_assert/inc)
 include_directories(${PROJECT_SOURCE_DIR}/fsw/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
-# Generate a dedicated "testrunner" executable that executes the tests for each FSW code unit
-# Although sample_app has only one source file, this is done in a loop such that 
-# the general pattern should work for several files as well.
-foreach(SRCFILE sample_app.c)
-    get_filename_component(UNITNAME "${SRCFILE}" NAME_WE)
-    
-    set(TESTNAME                "${UT_NAME}-${UNITNAME}")
-    set(UNIT_SOURCE_FILE        "${CFE_SAMPLE_APP_SOURCE_DIR}/fsw/src/${UNITNAME}.c")
-    set(TESTCASE_SOURCE_FILE    "coveragetest/coveragetest_${UNITNAME}.c")
-    
-    # Compile the source unit under test as a OBJECT
-    add_library(ut_${TESTNAME}_object OBJECT
-        ${UNIT_SOURCE_FILE}
-    )    
-    
-    # Apply the UT_COVERAGE_COMPILE_FLAGS to the units under test
-    # This should enable coverage analysis on platforms that support this
-    target_compile_options(ut_${TESTNAME}_object PRIVATE ${UT_COVERAGE_COMPILE_FLAGS})
-        
-    # Compile a test runner application, which contains the
-    # actual coverage test code (test cases) and the unit under test
-    add_executable(${TESTNAME}-testrunner
-        ${TESTCASE_SOURCE_FILE}
-        $<TARGET_OBJECTS:ut_${TESTNAME}_object>
-    )
-    
-    # This also needs to be linked with UT_COVERAGE_LINK_FLAGS (for coverage)
-    # This is also linked with any other stub libraries needed,
-    # as well as the UT assert framework    
-    target_link_libraries(${TESTNAME}-testrunner
-        ${UT_COVERAGE_LINK_FLAGS}
-        ut_sample_lib_stubs
-        ut_cfe-core_stubs
-        ut_assert
-    )
-    
-    # Add it to the set of tests to run as part of "make test"
-    add_test(${TESTNAME} ${TESTNAME}-testrunner)
-    foreach(TGT ${INSTALL_TARGET_LIST})
-        install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
-    endforeach()
-    
-endforeach()
+
+# Add a coverate test excutable called "sample_app-ALL" that 
+# covers all of the functions in sample_app.  
+#
+# Also note in a more complex app/lib the coverage test can also
+# be broken down into smaller units (in which case one should use
+# a unique suffix other than "ALL" for each unit).  For example,
+# OSAL implements a separate coverage test per source unit.
+add_cfe_coverage_test(sample_app ALL 
+    "coveragetest/coveragetest_sample_app.c"
+    "${CFE_SAMPLE_APP_SOURCE_DIR}/fsw/src/sample_app.c"
+)
+
+# The sample_app uses library functions provided by sample_lib so must be linked
+# with the sample_lib stub library (this is mainly just an example of how this 
+# can be done).
+add_cfe_coverage_dependency(sample_app ALL sample_lib)
 


### PR DESCRIPTION
**Describe the contribution**
Use the wrapper functions now provided by CFE to simplify the build recipe and work with interface libraries

Fixes #126

**Testing performed**
Build and run CFE unit tests

**Expected behavior changes**
Unit test targets are named a little differently when using the wrapper functions, but transparent if running via ctest.  The filename is different if running manually though.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Requires nasa/cfe#1207 and must be merged before nasa/cfe#1203 to avoid breaking UT

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
