### PR TITLE
Fix #133, Use quotes for local includes

### DIFF
--- a/unit-test/coveragetest/sample_app_coveragetest_common.h
+++ b/unit-test/coveragetest/sample_app_coveragetest_common.h
@@ -32,14 +32,14 @@
  * Includes
  */
 
-#include <utassert.h>
-#include <uttest.h>
-#include <utstubs.h>
+#include "utassert.h"
+#include "uttest.h"
+#include "utstubs.h"
 
-#include <cfe.h>
-#include <sample_app_events.h>
-#include <sample_app.h>
-#include <sample_app_table.h>
+#include "cfe.h"
+#include "sample_app_events.h"
+#include "sample_app.h"
+#include "sample_app_table.h"
 
 /*
  * Macro to call a function and check its int32 return code

--- a/unit-test/inc/ut_sample_app.h
+++ b/unit-test/inc/ut_sample_app.h
@@ -39,8 +39,8 @@
  * Necessary to include these here to get the definition of the
  * "SAMPLE_APP_Data_t" typedef.
  */
-#include <sample_app_events.h>
-#include <sample_app.h>
+#include "sample_app_events.h"
+#include "sample_app.h"
 
 /*
  * Allow UT access to the global "SAMPLE_APP_Data" object.


### PR DESCRIPTION
**Describe the contribution**
Fix #133 - convert from `<>` to `"` for local includes

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC