### PR TITLE
sample_app Integration candidate: 2021-03-23

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guide
+
+Please see our [top-level contributing guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md) for more information on how to contribute. 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ sample_app is an example for how to build and link an application in cFS. See al
 
 ## Version History
 
+### Development Build: 1.2.0-rc1+dev56
+
+- Replaces <> with " in local includes
+- Adds CONTRIBUTIING.md that links to the main cFS contributing guide.
+- Adds a description for the requirements of command and telemetry Message IDs to explain why the Msg IDs have those requirements in documentation.
+- See <https://github.com/nasa/sample_app/pull/137>
+
 ### Development Build: 1.2.0-rc1+dev48
 
 - Fix #126, simplify build to use wrappers and interface libs

--- a/fsw/platform_inc/sample_app_msgids.h
+++ b/fsw/platform_inc/sample_app_msgids.h
@@ -24,15 +24,20 @@
 **  Define Sample App  Message IDs
 **
 ** Notes:
-**
+**  Message ID bits relate to the message header based on which version
+**  of the message id implementation is being used
 **
 *************************************************************************/
 #ifndef _sample_app_msgids_h_
 #define _sample_app_msgids_h_
 
+/* The Sample App assumes default configuration which uses V1 of message id implementation */
+
+/* V1 Command Message IDs must be 0x18xx */
 #define SAMPLE_APP_CMD_MID     0x1882
 #define SAMPLE_APP_SEND_HK_MID 0x1883
-#define SAMPLE_APP_HK_TLM_MID  0x0883
+/* V1 Telemetry Message IDs must be 0x08xx */
+#define SAMPLE_APP_HK_TLM_MID 0x0883
 
 #endif /* _sample_app_msgids_h_ */
 

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -32,7 +32,7 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_APP_BUILD_NUMBER 48 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_APP_BUILD_NUMBER 56 /*!< Development Build: Number of commits since baseline */
 #define SAMPLE_APP_BUILD_BASELINE \
     "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 

--- a/unit-test/coveragetest/sample_app_coveragetest_common.h
+++ b/unit-test/coveragetest/sample_app_coveragetest_common.h
@@ -32,14 +32,14 @@
  * Includes
  */
 
-#include <utassert.h>
-#include <uttest.h>
-#include <utstubs.h>
+#include "utassert.h"
+#include "uttest.h"
+#include "utstubs.h"
 
-#include <cfe.h>
-#include <sample_app_events.h>
-#include <sample_app.h>
-#include <sample_app_table.h>
+#include "cfe.h"
+#include "sample_app_events.h"
+#include "sample_app.h"
+#include "sample_app_table.h"
 
 /*
  * Macro to call a function and check its int32 return code

--- a/unit-test/inc/ut_sample_app.h
+++ b/unit-test/inc/ut_sample_app.h
@@ -39,8 +39,8 @@
  * Necessary to include these here to get the definition of the
  * "SAMPLE_APP_Data_t" typedef.
  */
-#include <sample_app_events.h>
-#include <sample_app.h>
+#include "sample_app_events.h"
+#include "sample_app.h"
 
 /*
  * Allow UT access to the global "SAMPLE_APP_Data" object.


### PR DESCRIPTION
## Describe the contribution
Fix #133, convert from <> to " for local includes
Fix #135, Added a contributing guide that links to the main cFS contributing guide.
Fix #131, add context to the values for MsgIDs 

## Testing performed
See <https://github.com/nasa/cFS/pull/223/checks>

## Expected behavior changes

### PR #134 
Replaces `<>` with `"` in local includes

### PR #136 
Adds `CONTRIBUTIING.md` that links to the main cFS contributing guide.

### PR #132 
Adds a description for the requirements of command and telemetry Message IDs to explain why the Msg IDs have those requirements in documentation.

## Additional context
Part of <https://github.com/nasa/cFS/pull/223>

## Third party code
None


## Authors

@zanzaben
@skliper 
@ArielSAdamsNASA 