### PR TITLE
Fix #55, add timeout to SB receive

### DIFF
--- a/config/default_sample_app_internal_cfg.h
+++ b/config/default_sample_app_internal_cfg.h
@@ -42,4 +42,14 @@
 
 #define SAMPLE_APP_TBL_ELEMENT_1_MAX 10
 
+/**
+ * \brief Amount of time to wait in CFE_SB_RecieveBuffer
+ *
+ * Applications need to wait for messages to arrive on the Software Bus,
+ * but this wait should be time limited to ensure that the app also
+ * periodically checks the status of CFE_ES_RunLoop(), in case an
+ * administrative command comes in.
+ */
+#define SAMPLE_APP_SB_WAIT_PERIOD 1000
+
 #endif

--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -73,8 +73,14 @@ void SAMPLE_APP_Main(void)
         */
         CFE_ES_PerfLogExit(SAMPLE_APP_PERF_ID);
 
-        /* Pend on receipt of command packet */
-        status = CFE_SB_ReceiveBuffer(&SBBufPtr, SAMPLE_APP_Data.CommandPipe, CFE_SB_PEND_FOREVER);
+        /*
+         * Pend on receipt of command packet
+         *
+         * Note that apps should not wait forever here, to ensure
+         * that the status of CFE_ES_RunLoop() is also checked periodically,
+         * even if no software bus messages arrive.
+         */
+        status = CFE_SB_ReceiveBuffer(&SBBufPtr, SAMPLE_APP_Data.CommandPipe, SAMPLE_APP_SB_WAIT_PERIOD);
 
         /*
         ** Performance Log Entry Stamp
@@ -85,8 +91,9 @@ void SAMPLE_APP_Main(void)
         {
             SAMPLE_APP_TaskPipe(SBBufPtr);
         }
-        else
+        else if (status != CFE_SB_TIME_OUT)
         {
+            /* Timeout is normal if no activity, but anything else constitutes a real error */
             CFE_EVS_SendEvent(SAMPLE_APP_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "SAMPLE APP: SB Pipe Read Error, App Will Exit");
 


### PR DESCRIPTION
**Describe the contribution**
Apps should not pend forever on software bus receive, because they should also periodically check `CFE_ES_RunLoop` even if no
commands were received.

Fixes #55 

**Testing performed**
Build and sanity check CFE, confirm sample_app runs correctly

**Expected behavior changes**
Sample App will check CFE_ES_Runloop() (and therefore respond to a request from ES) even if it does not get any message on the software bus.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
As a "best practice" all apps should do something like this, instead of pending forever.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
