### PR TITLE
sample_app Integration candidate: 2021-03-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ sample_app is an example for how to build and link an application in cFS. See al
 
 ## Version History
 
+### Development Build: 1.2.0-rc1+dev62
+
+- Removes app registration call, `CFE_ES_RegisterApp()` since applications do not need to register themselves.
+- Apply standard header guard on all header files by removing leading underscore. Convert file-scope block comments to doxygen format.
+- See <https://github.com/nasa/sample_app/pull/145>
+
+
 ### Development Build: 1.2.0-rc1+dev56
 
 - Replaces <> with " in local includes

--- a/fsw/mission_inc/sample_app_perfids.h
+++ b/fsw/mission_inc/sample_app_perfids.h
@@ -18,21 +18,17 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_perfids.h
-**
-** Purpose:
-**  Define Sample App Performance IDs
-**
-** Notes:
-**
 *************************************************************************/
-#ifndef _sample_app_perfids_h_
-#define _sample_app_perfids_h_
+
+/**
+ * @file
+ *
+ * Define Sample App Performance IDs
+ */
+
+#ifndef SAMPLE_APP_PERFIDS_H
+#define SAMPLE_APP_PERFIDS_H
 
 #define SAMPLE_APP_PERF_ID 91
 
-#endif /* _sample_app_perfids_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* SAMPLE_APP_PERFIDS_H */

--- a/fsw/platform_inc/sample_app_msgids.h
+++ b/fsw/platform_inc/sample_app_msgids.h
@@ -18,20 +18,18 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_msgids.h
-**
-** Purpose:
-**  Define Sample App  Message IDs
-**
-** Notes:
-**  Message ID bits relate to the message header based on which version
-**  of the message id implementation is being used
-**
 *************************************************************************/
-#ifndef _sample_app_msgids_h_
-#define _sample_app_msgids_h_
 
-/* The Sample App assumes default configuration which uses V1 of message id implementation */
+/**
+ * @file
+ *
+ * Define Sample App Message IDs
+ *
+ * \note The Sample App assumes default configuration which uses V1 of message id implementation
+ */
+
+#ifndef SAMPLE_APP_MSGIDS_H
+#define SAMPLE_APP_MSGIDS_H
 
 /* V1 Command Message IDs must be 0x18xx */
 #define SAMPLE_APP_CMD_MID     0x1882
@@ -39,8 +37,4 @@
 /* V1 Telemetry Message IDs must be 0x08xx */
 #define SAMPLE_APP_HK_TLM_MID 0x0883
 
-#endif /* _sample_app_msgids_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* SAMPLE_APP_MSGIDS_H */

--- a/fsw/platform_inc/sample_app_table.h
+++ b/fsw/platform_inc/sample_app_table.h
@@ -18,17 +18,16 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_table.h
-**
-** Purpose:
-**  Define sample app table
-**
-** Notes:
-**
-**
 *******************************************************************************/
-#ifndef _sample_app_table_h_
-#define _sample_app_table_h_
+
+/**
+ * @file
+ *
+ * Define sample app table
+ */
+
+#ifndef SAMPLE_APP_TABLE_H
+#define SAMPLE_APP_TABLE_H
 
 /*
 ** Table structure
@@ -40,8 +39,4 @@ typedef struct
 
 } SAMPLE_APP_Table_t;
 
-#endif /* _sample_app_table_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* SAMPLE_APP_TABLE_H */

--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -52,11 +52,6 @@ void SAMPLE_APP_Main(void)
     CFE_SB_Buffer_t *SBBufPtr;
 
     /*
-    ** Register the app with Executive services
-    */
-    CFE_ES_RegisterApp();
-
-    /*
     ** Create the first Performance Log entry
     */
     CFE_ES_PerfLogEntry(SAMPLE_APP_PERF_ID);

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -18,16 +18,16 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app.h
-**
-** Purpose:
-**   This file is main hdr file for the SAMPLE application.
-**
-**
 *******************************************************************************/
 
-#ifndef _sample_app_h_
-#define _sample_app_h_
+/**
+ * @file
+ *
+ * Main header file for the SAMPLE application
+ */
+
+#ifndef SAMPLE_APP_H
+#define SAMPLE_APP_H
 
 /*
 ** Required header files.
@@ -115,4 +115,4 @@ int32 SAMPLE_APP_TblValidationFunc(void *TblData);
 
 bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
-#endif /* _sample_app_h_ */
+#endif /* SAMPLE_APP_H */

--- a/fsw/src/sample_app_events.h
+++ b/fsw/src/sample_app_events.h
@@ -18,16 +18,16 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_events.h
-**
-** Purpose:
-**  Define SAMPLE App Events IDs
-**
-** Notes:
-**
 *************************************************************************/
-#ifndef _sample_app_events_h_
-#define _sample_app_events_h_
+
+/**
+ * @file
+ *
+ * Define SAMPLE App Events IDs
+ */
+
+#ifndef SAMPLE_APP_EVENTS_H
+#define SAMPLE_APP_EVENTS_H
 
 #define SAMPLE_APP_RESERVED_EID          0
 #define SAMPLE_APP_STARTUP_INF_EID       1
@@ -40,8 +40,4 @@
 
 #define SAMPLE_APP_EVENT_COUNTS 7
 
-#endif /* _sample_app_events_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* SAMPLE_APP_EVENTS_H */

--- a/fsw/src/sample_app_msg.h
+++ b/fsw/src/sample_app_msg.h
@@ -18,17 +18,16 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_app_msg.h
-**
-** Purpose:
-**  Define SAMPLE App  Messages and info
-**
-** Notes:
-**
-**
 *******************************************************************************/
-#ifndef _sample_app_msg_h_
-#define _sample_app_msg_h_
+
+/**
+ * @file
+ *
+ * Define SAMPLE App  Messages and info
+ */
+
+#ifndef SAMPLE_APP_MSG_H
+#define SAMPLE_APP_MSG_H
 
 /*
 ** SAMPLE App command codes
@@ -76,8 +75,4 @@ typedef struct
     SAMPLE_APP_HkTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } SAMPLE_APP_HkTlm_t;
 
-#endif /* _sample_app_msg_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* SAMPLE_APP_MSG_H */

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -20,11 +20,10 @@
 **
 *************************************************************************/
 
-/*! @file sample_app_version.h
- * @brief Purpose:
+/**
+ * @file
  *
  *  The Sample App header file containing version information
- *
  */
 
 #ifndef SAMPLE_APP_VERSION_H
@@ -62,7 +61,3 @@
     ", Last Official Release: v1.1.0" /* For full support please use this version */
 
 #endif /* SAMPLE_APP_VERSION_H */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -31,7 +31,7 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_APP_BUILD_NUMBER 56 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_APP_BUILD_NUMBER 62 /*!< Development Build: Number of commits since baseline */
 #define SAMPLE_APP_BUILD_BASELINE \
     "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 

--- a/unit-test/coveragetest/sample_app_coveragetest_common.h
+++ b/unit-test/coveragetest/sample_app_coveragetest_common.h
@@ -18,15 +18,14 @@
 **  limitations under the License.
 */
 
-/*
-** File: sample_app_coveragetest_common.h
-**
-** Purpose:
-** Common definitions for all sample_app coverage tests
-*/
+/**
+ * @file
+ *
+ * Common definitions for all sample_app coverage tests
+ */
 
-#ifndef _SAMPLE_APP_COVERAGETEST_COMMON_H_
-#define _SAMPLE_APP_COVERAGETEST_COMMON_H_
+#ifndef SAMPLE_APP_COVERAGETEST_COMMON_H
+#define SAMPLE_APP_COVERAGETEST_COMMON_H
 
 /*
  * Includes
@@ -66,4 +65,4 @@ void Sample_UT_Setup(void);
  */
 void Sample_UT_TearDown(void);
 
-#endif
+#endif /* SAMPLE_APP_COVERAGETEST_COMMON_H */

--- a/unit-test/inc/ut_sample_app.h
+++ b/unit-test/inc/ut_sample_app.h
@@ -18,22 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-** File: ut_sample_app.h
-**
-** Purpose:
-** Extra scaffolding functions for the sample_app unit test
-**
-** Notes:
-** This is an extra UT-specific extern declaration
-** to obtain access to an internal data structure
-**
-** UT often needs to modify internal data structures in ways that
-** actual applications never would (bypassing the normal API) in
-** order to exercise or set up for off-nominal cases.
-*/
-#ifndef _UT_SAMPLE_APP_H_
-#define _UT_SAMPLE_APP_H_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ * Extra scaffolding functions for the sample_app unit test
+ *
+ * Notes:
+ * This is an extra UT-specific extern declaration
+ * to obtain access to an internal data structure
+ *
+ * UT often needs to modify internal data structures in ways that
+ * actual applications never would (bypassing the normal API) in
+ * order to exercise or set up for off-nominal cases.
+ */
+
+#ifndef UT_SAMPLE_APP_H
+#define UT_SAMPLE_APP_H
 
 /*
  * Necessary to include these here to get the definition of the
@@ -47,4 +49,4 @@
  */
 extern SAMPLE_APP_Data_t SAMPLE_APP_Data;
 
-#endif /* _UT_SAMPLE_APP_H_ */
+#endif /* UT_SAMPLE_APP_H */


### PR DESCRIPTION
## Describe the contribution

Fix #138, remove app registration
Fix #142, scrub header guards 


**Testing performed**
sample_app checks <https://github.com/nasa/sample_app/pull/145/checks> 
bundle checks <https://github.com/nasa/cFS/pull/227/checks>


## Expected behavior changes


### PR #139 

Removes app registration call, `CFE_ES_RegisterApp()` since applications do not need to register themselves.

### PR #143 

Apply standard header guard on all header files by removing leading underscore. Convert file-scope block comments to doxygen format.

## Additional Context
Part of <https://github.com/nasa/cFS/pull/227>

## Third party code
None

## Authors

@jphickey 