### PR TITLE
Fixed typos in readme docs and test error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sample_app is an example for how to build and link an application in cFS. See al
 ### Development Build: v1.2.0-rc1+dev56
 
 - Replaces <> with " in local includes
-- Adds CONTRIBUTIING.md that links to the main cFS contributing guide.
+- Adds CONTRIBUTING.md that links to the main cFS contributing guide.
 - Adds a description for the requirements of command and telemetry Message IDs to explain why the Msg IDs have those requirements in documentation.
 - See <https://github.com/nasa/sample_app/pull/137>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ To report a vulnerability for the sample_app subsystem please [submit an issue](
 
 For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy) for additional information.
 
-In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropriate labels for each report. For security related reports, tag the issue with the "security" label.
 
 ## Testing
 

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(${PROJECT_SOURCE_DIR}/fsw/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
 
-# Add a coverate test excutable called "sample_app-ALL" that 
+# Add a coverage test executable called "sample_app-ALL" that 
 # covers all of the functions in sample_app.  
 #
 # Also note in a more complex app/lib the coverage test can also

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -423,7 +423,7 @@ void Test_SAMPLE_APP_ReportHousekeeping(void)
     /* Confirm timestamp msg address */
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_SB_TimeStampMsg)) == 1, "CFE_SB_TimeStampMsg() called once");
     UtAssert_True(MsgTimestamp == &SAMPLE_APP_Data.HkTlm.TlmHeader.Msg,
-                  "CFE_SB_TimeStampMsg() adress matches expected");
+                  "CFE_SB_TimeStampMsg() address matches expected");
 
     /*
      * Confirm that the CFE_TBL_Manage() call was done


### PR DESCRIPTION
**Describe the contribution**
Fixed a few minor typos in the _text_ of:
- README.md
- SECURITY.md
  
...and in the _comments_ of:
- unit-test/CMakeLists.txt 
  
...and in an _assert error message_ string of:
- unit-test/coveragetest/coveragetest_sample_app.c
  
**Testing performed**
Only automated checks.

**Expected behavior changes**
None (minor Markdown doc, comments changes, and assert error string changes that do not interact with any max lengths etc.).

**System(s) tested on**
n/a

**Additional context**
n/a

**Code contributions**
n/a