### PR TITLE
Fix #153, apply CFE_SB_ValueToMsgId where required

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -163,7 +163,8 @@ int32 SAMPLE_APP_Init(void)
     /*
     ** Initialize housekeeping packet (clear user data area).
     */
-    CFE_MSG_Init(&SAMPLE_APP_Data.HkTlm.TlmHeader.Msg, SAMPLE_APP_HK_TLM_MID, sizeof(SAMPLE_APP_Data.HkTlm));
+    CFE_MSG_Init(&SAMPLE_APP_Data.HkTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(SAMPLE_APP_HK_TLM_MID),
+                 sizeof(SAMPLE_APP_Data.HkTlm));
 
     /*
     ** Create Software Bus message pipe.
@@ -178,7 +179,7 @@ int32 SAMPLE_APP_Init(void)
     /*
     ** Subscribe to Housekeeping request commands
     */
-    status = CFE_SB_Subscribe(SAMPLE_APP_SEND_HK_MID, SAMPLE_APP_Data.CommandPipe);
+    status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SAMPLE_APP_SEND_HK_MID), SAMPLE_APP_Data.CommandPipe);
     if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Subscribing to HK request, RC = 0x%08lX\n", (unsigned long)status);
@@ -188,7 +189,7 @@ int32 SAMPLE_APP_Init(void)
     /*
     ** Subscribe to ground command packets
     */
-    status = CFE_SB_Subscribe(SAMPLE_APP_CMD_MID, SAMPLE_APP_Data.CommandPipe);
+    status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SAMPLE_APP_CMD_MID), SAMPLE_APP_Data.CommandPipe);
     if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Subscribing to Command, RC = 0x%08lX\n", (unsigned long)status);
@@ -233,7 +234,7 @@ void SAMPLE_APP_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
 
     CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MsgId);
 
-    switch (MsgId)
+    switch (CFE_SB_MsgIdToValue(MsgId))
     {
         case SAMPLE_APP_CMD_MID:
             SAMPLE_APP_ProcessGroundCommand(SBBufPtr);

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -292,7 +292,7 @@ void Test_SAMPLE_APP_ProcessCommandPacket(void)
      * The CFE_MSG_GetMsgId() stub uses a data buffer to hold the
      * message ID values to return.
      */
-    TestMsgId = SAMPLE_APP_CMD_MID;
+    TestMsgId = CFE_SB_ValueToMsgId(SAMPLE_APP_CMD_MID);
     FcnCode   = SAMPLE_APP_NOOP_CC;
     MsgSize   = sizeof(TestMsg.Noop);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -300,7 +300,7 @@ void Test_SAMPLE_APP_ProcessCommandPacket(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
     SAMPLE_APP_ProcessCommandPacket(&TestMsg.SBBuf);
 
-    TestMsgId = SAMPLE_APP_SEND_HK_MID;
+    TestMsgId = CFE_SB_ValueToMsgId(SAMPLE_APP_SEND_HK_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     SAMPLE_APP_ProcessCommandPacket(&TestMsg.SBBuf);
 


### PR DESCRIPTION
**Describe the contribution**
Whenever an integer value is used as a CFE_SB_MsgId_t, it should go through the explicit conversion using the supplied inline function.

Fixes #153

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
Allows SAMPLE_APP to be built when CFE_SB_MsgId_t is an opaque/non-integer type.
None with default config (where CFE_SB_MsgId_t is an integer type).

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.