### PR TITLE
Fix #156, Use CFE_MSG_PTR conversion macro

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -163,7 +163,7 @@ int32 SAMPLE_APP_Init(void)
     /*
     ** Initialize housekeeping packet (clear user data area).
     */
-    CFE_MSG_Init(&SAMPLE_APP_Data.HkTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(SAMPLE_APP_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(SAMPLE_APP_Data.HkTlm.TelemetryHeader), CFE_SB_ValueToMsgId(SAMPLE_APP_HK_TLM_MID),
                  sizeof(SAMPLE_APP_Data.HkTlm));
 
     /*
@@ -327,8 +327,8 @@ int32 SAMPLE_APP_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg)
     /*
     ** Send housekeeping telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&SAMPLE_APP_Data.HkTlm.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&SAMPLE_APP_Data.HkTlm.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(SAMPLE_APP_Data.HkTlm.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(SAMPLE_APP_Data.HkTlm.TelemetryHeader), true);
 
     /*
     ** Manage any pending table loads, validations, etc.

--- a/fsw/src/sample_app_msg.h
+++ b/fsw/src/sample_app_msg.h
@@ -71,8 +71,8 @@ typedef struct
 
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
-    SAMPLE_APP_HkTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t  TelemetryHeader; /**< \brief Telemetry header */
+    SAMPLE_APP_HkTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } SAMPLE_APP_HkTlm_t;
 
 #endif /* SAMPLE_APP_MSG_H */

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -418,12 +418,11 @@ void Test_SAMPLE_APP_ReportHousekeeping(void)
 
     /* Confirm message sent*/
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_SB_TransmitMsg)) == 1, "CFE_SB_TransmitMsg() called once");
-    UtAssert_True(MsgSend == &SAMPLE_APP_Data.HkTlm.TlmHeader.Msg, "CFE_SB_TransmitMsg() address matches expected");
+    UtAssert_ADDRESS_EQ(MsgSend, &SAMPLE_APP_Data.HkTlm);
 
     /* Confirm timestamp msg address */
     UtAssert_True(UT_GetStubCount(UT_KEY(CFE_SB_TimeStampMsg)) == 1, "CFE_SB_TimeStampMsg() called once");
-    UtAssert_True(MsgTimestamp == &SAMPLE_APP_Data.HkTlm.TlmHeader.Msg,
-                  "CFE_SB_TimeStampMsg() address matches expected");
+    UtAssert_ADDRESS_EQ(MsgTimestamp, &SAMPLE_APP_Data.HkTlm);
 
     /*
      * Confirm that the CFE_TBL_Manage() call was done


### PR DESCRIPTION
**Describe the contribution**
Updates conversions to CFE_Message_t to use the MSG macro
This also uses consistent naming - TelemetryHeader rather than TlmHeader

Fixes #156

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
Depends on nasa/cfe#1966

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
