### PR TITLE
Fix #178, Remove unnecessary parentheses around return values.

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -157,7 +157,7 @@ int32 SAMPLE_APP_Init(void)
     if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Registering Events, RC = 0x%08lX\n", (unsigned long)status);
-        return (status);
+        return status;
     }
 
     /*
@@ -172,7 +172,7 @@ int32 SAMPLE_APP_Init(void)
     if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Error creating pipe, RC = 0x%08lX\n", (unsigned long)status);
-        return (status);
+        return status;
     }
 
     /*
@@ -182,7 +182,7 @@ int32 SAMPLE_APP_Init(void)
     if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Subscribing to HK request, RC = 0x%08lX\n", (unsigned long)status);
-        return (status);
+        return status;
     }
 
     /*
@@ -193,7 +193,7 @@ int32 SAMPLE_APP_Init(void)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Subscribing to Command, RC = 0x%08lX\n", (unsigned long)status);
 
-        return (status);
+        return status;
     }
 
     /*
@@ -205,7 +205,7 @@ int32 SAMPLE_APP_Init(void)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Registering Table, RC = 0x%08lX\n", (unsigned long)status);
 
-        return (status);
+        return status;
     }
     else
     {
@@ -215,7 +215,7 @@ int32 SAMPLE_APP_Init(void)
     CFE_EVS_SendEvent(SAMPLE_APP_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE App Initialized.%s",
                       SAMPLE_APP_VERSION_STRING);
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 
 } /* End of SAMPLE_APP_Init() */
 
@@ -451,7 +451,7 @@ bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength
         SAMPLE_APP_Data.ErrCounter++;
     }
 
-    return (result);
+    return result;
 
 } /* End of SAMPLE_APP_VerifyCmdLength() */
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #178 
Removes parentheses in return statements in sample_app that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 