### PR TITLE
Fix #167, Rename CommandCode variable to FcnCode

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -234,14 +234,14 @@ void SAMPLE_APP_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 void SAMPLE_APP_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr)
 {
-    CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_MSG_FcnCode_t FcnCode = 0;
 
-    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
+    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &FcnCode);
 
     /*
     ** Process "known" SAMPLE app ground commands
     */
-    switch (CommandCode)
+    switch (FcnCode)
     {
         case SAMPLE_APP_NOOP_CC:
             if (SAMPLE_APP_VerifyCmdLength(&SBBufPtr->Msg, sizeof(SAMPLE_APP_NoopCmd_t)))
@@ -270,7 +270,7 @@ void SAMPLE_APP_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr)
         /* default case already found during FC vs length test */
         default:
             CFE_EVS_SendEvent(SAMPLE_APP_COMMAND_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Invalid ground command code: CC = %d", CommandCode);
+                              "Invalid ground command code: CC = %d", FcnCode);
             break;
     }
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #167
  - Rename the CommandCode variable in SAMPLE_APP_ProcessGroundCommand() to FcnCode to better align with the cFE API.

**Testing performed**
Standard cFS bundle tests all passed.
Build/run cFS and test NOOP and other commands with the GroundSystem tool. All working fine.

**Expected behavior changes**
No impact on behavior.
Improves code clarity and consistency in the lab apps.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
cFE v7.0.0-rc4+dev197, OSAL v6.0.0-rc4+dev143, PSP v1.6.0-rc4+d
Sample App v1.3.0-rc4+dev35
CI Lab App v2.5.0-rc4+dev39
TO Lab v2.5.0-rc4+dev31

**Contributor Info**
Avi Weiss @thnkslprpt