### PR TITLE
Fix #147, Add check for success of CFE_TBL_Load() during Initialization

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -189,6 +189,12 @@ int32 SAMPLE_APP_Init(void)
     else
     {
         status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_TABLE_FILE);
+        if (status != CFE_SUCCESS)
+        {
+            CFE_ES_WriteToSysLog("Sample App: Error Loading Table, RC = 0x%08lX\n", (unsigned long)status);
+
+            return status;
+        }
     }
 
     CFE_EVS_SendEvent(SAMPLE_APP_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE App Initialized.%s",


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #147 
  - Adds check for success of `CFE_TBL_Load()`, if unsuccessful reports `"Error Loading Table..."` and returns early with error code returned from `CFE_TBL_Load()`.

**Testing performed**
Tested using same steps as @jphickey used in raising the issue (Start cFS without the sample app table file present in the /cf directory). Confirmed action of new code as per screenshot below:
![Screenshot 2022-10-24 13 15 05](https://user-images.githubusercontent.com/9024662/197443839-2ef60760-4652-44e0-b3cd-74df182c98cb.png)

**Expected behavior changes**
Sample App will exit during initialization if return value of `CFE_TBL_Load()` is not `CFE_SUCCESS`.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
cFE v7.0.0-rc4+dev197
Sample App v1.3.0-rc4+dev35

**Contributor Info**
Avi Weiss @thnkslprpt