### PR TITLE
Fix #78, Align use of Table/Tbl mnemonics

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -188,7 +188,7 @@ int32 SAMPLE_APP_Init(void)
     }
     else
     {
-        status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_TABLE_FILE);
+        status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_TBL_FILE);
     }
 
     CFE_EVS_SendEvent(SAMPLE_APP_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE App Initialized.%s",
@@ -352,7 +352,7 @@ int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg)
 {
     int32               status;
     SAMPLE_APP_Table_t *TblPtr;
-    const char *        TableName = "SAMPLE_APP.SampleAppTable";
+    const char *        TblName = "SAMPLE_APP.SampleAppTable";
 
     /* Sample Use of Table */
 
@@ -366,7 +366,7 @@ int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg)
 
     CFE_ES_WriteToSysLog("Sample App: Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
 
-    SAMPLE_APP_GetCrc(TableName);
+    SAMPLE_APP_GetCrc(TblName);
 
     status = CFE_TBL_ReleaseAddress(SAMPLE_APP_Data.TblHandles[0]);
     if (status != CFE_SUCCESS)
@@ -432,7 +432,7 @@ int32 SAMPLE_APP_TblValidationFunc(void *TblData)
     if (TblDataPtr->Int1 > SAMPLE_APP_TBL_ELEMENT_1_MAX)
     {
         /* First element is out of range, return an appropriate error code */
-        ReturnCode = SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE;
+        ReturnCode = SAMPLE_APP_TBL_OUT_OF_RANGE_ERR_CODE;
     }
 
     return ReturnCode;
@@ -443,13 +443,13 @@ int32 SAMPLE_APP_TblValidationFunc(void *TblData)
 /* Output CRC                                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SAMPLE_APP_GetCrc(const char *TableName)
+void SAMPLE_APP_GetCrc(const char *TblName)
 {
     int32          status;
     uint32         Crc;
     CFE_TBL_Info_t TblInfoPtr;
 
-    status = CFE_TBL_GetInfo(&TblInfoPtr, TableName);
+    status = CFE_TBL_GetInfo(&TblInfoPtr, TblName);
     if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("Sample App: Error Getting Table Info");

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -44,9 +44,9 @@
 #define SAMPLE_APP_NUMBER_OF_TABLES 1 /* Number of Table(s) */
 
 /* Define filenames of default data images for tables */
-#define SAMPLE_APP_TABLE_FILE "/cf/sample_app_tbl.tbl"
+#define SAMPLE_APP_TBL_FILE "/cf/sample_app_tbl.tbl"
 
-#define SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE -1
+#define SAMPLE_APP_TBL_OUT_OF_RANGE_ERR_CODE -1
 
 #define SAMPLE_APP_TBL_ELEMENT_1_MAX 10
 /************************************************************************
@@ -103,7 +103,7 @@ int32 SAMPLE_APP_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg);
 int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCountersCmd_t *Msg);
 int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg);
 int32 SAMPLE_APP_Noop(const SAMPLE_APP_NoopCmd_t *Msg);
-void  SAMPLE_APP_GetCrc(const char *TableName);
+void  SAMPLE_APP_GetCrc(const char *TblName);
 
 int32 SAMPLE_APP_TblValidationFunc(void *TblData);
 

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -564,16 +564,16 @@ void Test_SAMPLE_APP_TblValidationFunc(void)
     /* nominal case (0) should succeed */
     UtAssert_INT32_EQ(SAMPLE_APP_TblValidationFunc(&TestTblData), CFE_SUCCESS);
 
-    /* error case should return SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE */
+    /* error case should return SAMPLE_APP_TBL_OUT_OF_RANGE_ERR_CODE */
     TestTblData.Int1 = 1 + SAMPLE_APP_TBL_ELEMENT_1_MAX;
-    UtAssert_INT32_EQ(SAMPLE_APP_TblValidationFunc(&TestTblData), SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE);
+    UtAssert_INT32_EQ(SAMPLE_APP_TblValidationFunc(&TestTblData), SAMPLE_APP_TBL_OUT_OF_RANGE_ERR_CODE);
 }
 
 void Test_SAMPLE_APP_GetCrc(void)
 {
     /*
      * Test Case For:
-     * void SAMPLE_APP_GetCrc( const char *TableName )
+     * void SAMPLE_APP_GetCrc( const char *TblName )
      */
 
     /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #78
Aligns use of Table/Tbl mnemonics in sample_app.
The macros and function parameters that used 'table' have been converted to 'tbl'.
I left the table struct (`SAMPLE_APP_Table_t`) as is for now, because this is the more common convention in cFS.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt