### PR TITLE
Fix #148, Update add_cfe_tables APP_NAME parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_cfe_app(sample_app fsw/src/sample_app.c)
 add_cfe_app_dependency(sample_app sample_lib)
 
 # Add table
-add_cfe_tables(sampleAppTable fsw/tables/sample_app_tbl.c)
+add_cfe_tables(sample_app fsw/tables/sample_app_tbl.c)
 
 # If UT is enabled, then add the tests from the subdirectory
 # Note that this is an app, and therefore does not provide


### PR DESCRIPTION
**Describe the contribution**
- Fixes #148
  - Corrects first parameter of `add_cfe_tables` CMake function.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.
Confirmed locally with start-up test and ground-system commands.

**Expected behavior changes**
No change to behavior with current implementation.

**Contributor Info**
Avi Weiss @thnkslprpt