### PR TITLE
Fix #141, Zero out global data structure during initialization

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -112,13 +112,10 @@ int32 SAMPLE_APP_Init(void)
 {
     int32 status;
 
-    SAMPLE_APP_Data.RunStatus = CFE_ES_RunStatus_APP_RUN;
+    /* Zero out the global data structure */
+    memset(&SAMPLE_APP_Data, 0, sizeof(SAMPLE_APP_Data));
 
-    /*
-    ** Initialize app command execution counters
-    */
-    SAMPLE_APP_Data.CmdCounter = 0;
-    SAMPLE_APP_Data.ErrCounter = 0;
+    SAMPLE_APP_Data.RunStatus = CFE_ES_RunStatus_APP_RUN;
 
     /*
     ** Initialize app configuration data


### PR DESCRIPTION
**Describe the contribution**
- Fixes #141 
  - Added a `memset` to zero out the global data structure at the beginning of the app's initialization.

**Testing performed**
GitHub CI actions passing successfully and local test confirms all tests passing and no change to coverage due to these changes.

**Expected behavior changes**
No change to behavior. The entire struct is now assured to start out initialized to zero.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt