### PR TITLE
Fix #45, Move cmds and utils into separate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 project(CFE_SAMPLE_APP C)
 
 # Create the app module
-add_cfe_app(sample_app fsw/src/sample_app.c)
+add_cfe_app(sample_app fsw/src/sample_app.c
+                       fsw/src/sample_app_cmds.c
+                       fsw/src/sample_app_utils.c)
 
 # Include the public API from sample_lib to demonstrate how
 # to call library-provided functions

--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -24,14 +24,14 @@
 /*
 ** Include Files:
 */
+#include <string.h>
+
+#include "sample_app.h"
+#include "sample_app_cmds.h"
+#include "sample_app_utils.h"
 #include "sample_app_events.h"
 #include "sample_app_version.h"
-#include "sample_app.h"
 #include "sample_app_table.h"
-
-/* The sample_lib module provides the SAMPLE_LIB_Function() prototype */
-#include <string.h>
-#include "sample_lib.h"
 
 /*
 ** global data
@@ -308,155 +308,4 @@ int32 SAMPLE_APP_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg)
     }
 
     return CFE_SUCCESS;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-/*                                                                            */
-/* SAMPLE NOOP commands                                                       */
-/*                                                                            */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-int32 SAMPLE_APP_Noop(const SAMPLE_APP_NoopCmd_t *Msg)
-{
-    SAMPLE_APP_Data.CmdCounter++;
-
-    CFE_EVS_SendEvent(SAMPLE_APP_COMMANDNOP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: NOOP command %s",
-                      SAMPLE_APP_VERSION);
-
-    return CFE_SUCCESS;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-/*                                                                            */
-/*  Purpose:                                                                  */
-/*         This function resets all the global counter variables that are     */
-/*         part of the task telemetry.                                        */
-/*                                                                            */
-/* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
-int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCountersCmd_t *Msg)
-{
-    SAMPLE_APP_Data.CmdCounter = 0;
-    SAMPLE_APP_Data.ErrCounter = 0;
-
-    CFE_EVS_SendEvent(SAMPLE_APP_COMMANDRST_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: RESET command");
-
-    return CFE_SUCCESS;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-/*                                                                            */
-/*  Purpose:                                                                  */
-/*         This function Process Ground Station Command                       */
-/*                                                                            */
-/* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
-int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg)
-{
-    int32               status;
-    SAMPLE_APP_Table_t *TblPtr;
-    const char *        TableName = "SAMPLE_APP.SampleAppTable";
-
-    /* Sample Use of Table */
-
-    status = CFE_TBL_GetAddress((void *)&TblPtr, SAMPLE_APP_Data.TblHandles[0]);
-
-    if (status < CFE_SUCCESS)
-    {
-        CFE_ES_WriteToSysLog("Sample App: Fail to get table address: 0x%08lx", (unsigned long)status);
-        return status;
-    }
-
-    CFE_ES_WriteToSysLog("Sample App: Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
-
-    SAMPLE_APP_GetCrc(TableName);
-
-    status = CFE_TBL_ReleaseAddress(SAMPLE_APP_Data.TblHandles[0]);
-    if (status != CFE_SUCCESS)
-    {
-        CFE_ES_WriteToSysLog("Sample App: Fail to release table address: 0x%08lx", (unsigned long)status);
-        return status;
-    }
-
-    /* Invoke a function provided by SAMPLE_APP_LIB */
-    SAMPLE_LIB_Function();
-
-    return CFE_SUCCESS;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-/*                                                                            */
-/* Verify command packet length                                               */
-/*                                                                            */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
-{
-    bool              result       = true;
-    size_t            ActualLength = 0;
-    CFE_SB_MsgId_t    MsgId        = CFE_SB_INVALID_MSG_ID;
-    CFE_MSG_FcnCode_t FcnCode      = 0;
-
-    CFE_MSG_GetSize(MsgPtr, &ActualLength);
-
-    /*
-    ** Verify the command packet length.
-    */
-    if (ExpectedLength != ActualLength)
-    {
-        CFE_MSG_GetMsgId(MsgPtr, &MsgId);
-        CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
-
-        CFE_EVS_SendEvent(SAMPLE_APP_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Invalid Msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
-                          (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
-                          (unsigned int)ExpectedLength);
-
-        result = false;
-
-        SAMPLE_APP_Data.ErrCounter++;
-    }
-
-    return result;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify contents of First Table buffer contents                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_APP_TblValidationFunc(void *TblData)
-{
-    int32               ReturnCode = CFE_SUCCESS;
-    SAMPLE_APP_Table_t *TblDataPtr = (SAMPLE_APP_Table_t *)TblData;
-
-    /*
-    ** Sample Table Validation
-    */
-    if (TblDataPtr->Int1 > SAMPLE_APP_TBL_ELEMENT_1_MAX)
-    {
-        /* First element is out of range, return an appropriate error code */
-        ReturnCode = SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE;
-    }
-
-    return ReturnCode;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Output CRC                                                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void SAMPLE_APP_GetCrc(const char *TableName)
-{
-    int32          status;
-    uint32         Crc;
-    CFE_TBL_Info_t TblInfoPtr;
-
-    status = CFE_TBL_GetInfo(&TblInfoPtr, TableName);
-    if (status != CFE_SUCCESS)
-    {
-        CFE_ES_WriteToSysLog("Sample App: Error Getting Table Info");
-    }
-    else
-    {
-        Crc = TblInfoPtr.Crc;
-        CFE_ES_WriteToSysLog("Sample App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
-    }
 }

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -88,6 +88,11 @@ typedef struct
     CFE_TBL_Handle_t TblHandles[SAMPLE_APP_NUMBER_OF_TABLES];
 } SAMPLE_APP_Data_t;
 
+/*
+** Global data structure
+*/
+extern SAMPLE_APP_Data_t SAMPLE_APP_Data;
+
 /****************************************************************************/
 /*
 ** Local function prototypes.
@@ -100,13 +105,5 @@ int32 SAMPLE_APP_Init(void);
 void  SAMPLE_APP_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
 void  SAMPLE_APP_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr);
 int32 SAMPLE_APP_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg);
-int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCountersCmd_t *Msg);
-int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg);
-int32 SAMPLE_APP_Noop(const SAMPLE_APP_NoopCmd_t *Msg);
-void  SAMPLE_APP_GetCrc(const char *TableName);
-
-int32 SAMPLE_APP_TblValidationFunc(void *TblData);
-
-bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
 #endif /* SAMPLE_APP_H */

--- a/fsw/src/sample_app_cmds.c
+++ b/fsw/src/sample_app_cmds.c
@@ -1,0 +1,107 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *   This file contains the source code for the Sample App Ground Command-handling functions
+ */
+
+/*
+** Include Files:
+*/
+#include "sample_app.h"
+#include "sample_app_cmds.h"
+#include "sample_app_events.h"
+#include "sample_app_version.h"
+#include "sample_app_table.h"
+#include "sample_app_utils.h"
+#include "sample_app_msg.h"
+
+/* The sample_lib module provides the SAMPLE_Function() prototype */
+#include "sample_lib.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+/*                                                                            */
+/* SAMPLE NOOP commands                                                       */
+/*                                                                            */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+int32 SAMPLE_APP_Noop(const SAMPLE_APP_NoopCmd_t *Msg)
+{
+    SAMPLE_APP_Data.CmdCounter++;
+
+    CFE_EVS_SendEvent(SAMPLE_APP_COMMANDNOP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: NOOP command %s",
+                      SAMPLE_APP_VERSION);
+
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+/*                                                                            */
+/*  Purpose:                                                                  */
+/*         This function resets all the global counter variables that are     */
+/*         part of the task telemetry.                                        */
+/*                                                                            */
+/* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
+int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCountersCmd_t *Msg)
+{
+    SAMPLE_APP_Data.CmdCounter = 0;
+    SAMPLE_APP_Data.ErrCounter = 0;
+
+    CFE_EVS_SendEvent(SAMPLE_APP_COMMANDRST_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: RESET command");
+
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+/*                                                                            */
+/*  Purpose:                                                                  */
+/*         This function Process Ground Station Command                       */
+/*                                                                            */
+/* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
+int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg)
+{
+    int32               status;
+    SAMPLE_APP_Table_t *TblPtr;
+    const char *        TableName = "SAMPLE_APP.SampleAppTable";
+
+    /* Sample Use of Table */
+
+    status = CFE_TBL_GetAddress((void *)&TblPtr, SAMPLE_APP_Data.TblHandles[0]);
+
+    if (status < CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Sample App: Fail to get table address: 0x%08lx", (unsigned long)status);
+        return status;
+    }
+
+    CFE_ES_WriteToSysLog("Sample App: Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
+
+    SAMPLE_APP_GetCrc(TableName);
+
+    status = CFE_TBL_ReleaseAddress(SAMPLE_APP_Data.TblHandles[0]);
+    if (status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Sample App: Fail to release table address: 0x%08lx", (unsigned long)status);
+        return status;
+    }
+
+    /* Invoke a function provided by SAMPLE_APP_LIB */
+    SAMPLE_LIB_Function();
+
+    return CFE_SUCCESS;
+}

--- a/fsw/src/sample_app_cmds.h
+++ b/fsw/src/sample_app_cmds.h
@@ -18,41 +18,19 @@
 
 /**
  * @file
- *
- * Common definitions for all sample_app coverage tests
+ *   This file contains the prototypes for the Sample App Ground Command-handling functions
  */
 
-#ifndef SAMPLE_APP_COVERAGETEST_COMMON_H
-#define SAMPLE_APP_COVERAGETEST_COMMON_H
+#ifndef SAMPLE_APP_CMDS_H
+#define SAMPLE_APP_CMDS_H
 
 /*
- * Includes
- */
-
-#include "utassert.h"
-#include "uttest.h"
-#include "utstubs.h"
-
-#include "cfe.h"
+** Required header files.
+*/
 #include "sample_app.h"
-#include "sample_app_cmds.h"
-#include "sample_app_utils.h"
-#include "sample_app_events.h"
-#include "sample_app_table.h"
 
-/*
- * Macro to add a test case to the list of tests to execute
- */
-#define ADD_TEST(test) UtTest_Add((Test_##test), Sample_UT_Setup, Sample_UT_TearDown, #test)
+int32 SAMPLE_APP_ResetCounters(const SAMPLE_APP_ResetCountersCmd_t *Msg);
+int32 SAMPLE_APP_Process(const SAMPLE_APP_ProcessCmd_t *Msg);
+int32 SAMPLE_APP_Noop(const SAMPLE_APP_NoopCmd_t *Msg);
 
-/*
- * Setup function prior to every test
- */
-void Sample_UT_Setup(void);
-
-/*
- * Teardown function after every test
- */
-void Sample_UT_TearDown(void);
-
-#endif /* SAMPLE_APP_COVERAGETEST_COMMON_H */
+#endif /* SAMPLE_APP_CMDS_H */

--- a/fsw/src/sample_app_utils.c
+++ b/fsw/src/sample_app_utils.c
@@ -1,0 +1,110 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *   This file contains the source code for the Sample App utility functions
+ */
+
+/*
+** Include Files:
+*/
+#include "sample_app.h"
+#include "sample_app_events.h"
+#include "sample_app_table.h"
+#include "sample_app_utils.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+/*                                                                            */
+/* Verify command packet length                                               */
+/*                                                                            */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+bool SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
+{
+    bool              result       = true;
+    size_t            ActualLength = 0;
+    CFE_SB_MsgId_t    MsgId        = CFE_SB_INVALID_MSG_ID;
+    CFE_MSG_FcnCode_t FcnCode      = 0;
+
+    CFE_MSG_GetSize(MsgPtr, &ActualLength);
+
+    /*
+    ** Verify the command packet length.
+    */
+    if (ExpectedLength != ActualLength)
+    {
+        CFE_MSG_GetMsgId(MsgPtr, &MsgId);
+        CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
+
+        CFE_EVS_SendEvent(SAMPLE_APP_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Invalid Msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
+                          (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
+                          (unsigned int)ExpectedLength);
+
+        result = false;
+
+        SAMPLE_APP_Data.ErrCounter++;
+    }
+
+    return result;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Verify contents of First Table buffer contents                  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 SAMPLE_APP_TblValidationFunc(void *TblData)
+{
+    int32               ReturnCode = CFE_SUCCESS;
+    SAMPLE_APP_Table_t *TblDataPtr = (SAMPLE_APP_Table_t *)TblData;
+
+    /*
+    ** Sample Table Validation
+    */
+    if (TblDataPtr->Int1 > SAMPLE_APP_TBL_ELEMENT_1_MAX)
+    {
+        /* First element is out of range, return an appropriate error code */
+        ReturnCode = SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE;
+    }
+
+    return ReturnCode;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Output CRC                                                      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void SAMPLE_APP_GetCrc(const char *TableName)
+{
+    int32          status;
+    uint32         Crc;
+    CFE_TBL_Info_t TblInfoPtr;
+
+    status = CFE_TBL_GetInfo(&TblInfoPtr, TableName);
+    if (status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Sample App: Error Getting Table Info");
+    }
+    else
+    {
+        Crc = TblInfoPtr.Crc;
+        CFE_ES_WriteToSysLog("Sample App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
+    }
+}

--- a/fsw/src/sample_app_utils.h
+++ b/fsw/src/sample_app_utils.h
@@ -18,41 +18,19 @@
 
 /**
  * @file
- *
- * Common definitions for all sample_app coverage tests
+ *   This file contains the prototypes for the Sample App utility functions
  */
 
-#ifndef SAMPLE_APP_COVERAGETEST_COMMON_H
-#define SAMPLE_APP_COVERAGETEST_COMMON_H
+#ifndef SAMPLE_APP_UTILS_H
+#define SAMPLE_APP_UTILS_H
 
 /*
- * Includes
- */
-
-#include "utassert.h"
-#include "uttest.h"
-#include "utstubs.h"
-
-#include "cfe.h"
+** Required header files.
+*/
 #include "sample_app.h"
-#include "sample_app_cmds.h"
-#include "sample_app_utils.h"
-#include "sample_app_events.h"
-#include "sample_app_table.h"
 
-/*
- * Macro to add a test case to the list of tests to execute
- */
-#define ADD_TEST(test) UtTest_Add((Test_##test), Sample_UT_Setup, Sample_UT_TearDown, #test)
+bool  SAMPLE_APP_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
+int32 SAMPLE_APP_TblValidationFunc(void *TblData);
+void  SAMPLE_APP_GetCrc(const char *TableName);
 
-/*
- * Setup function prior to every test
- */
-void Sample_UT_Setup(void);
-
-/*
- * Teardown function after every test
- */
-void Sample_UT_TearDown(void);
-
-#endif /* SAMPLE_APP_COVERAGETEST_COMMON_H */
+#endif /* SAMPLE_APP_UTILS_H */

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -23,7 +23,6 @@
 include_directories(${PROJECT_SOURCE_DIR}/fsw/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
-
 # Add a coverage test executable called "sample_app-ALL" that 
 # covers all of the functions in sample_app.  
 #
@@ -34,6 +33,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
 add_cfe_coverage_test(sample_app ALL 
     "coveragetest/coveragetest_sample_app.c"
     "${CFE_SAMPLE_APP_SOURCE_DIR}/fsw/src/sample_app.c"
+    "${CFE_SAMPLE_APP_SOURCE_DIR}/fsw/src/sample_app_cmds.c"
+    "${CFE_SAMPLE_APP_SOURCE_DIR}/fsw/src/sample_app_utils.c"
 )
 
 # The sample_app uses library functions provided by sample_lib so must be linked

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -35,7 +35,6 @@
 /*
  * Includes
  */
-
 #include "sample_lib.h" /* For SAMPLE_LIB_Function */
 #include "sample_app_coveragetest_common.h"
 #include "ut_sample_app.h"

--- a/unit-test/inc/ut_sample_app.h
+++ b/unit-test/inc/ut_sample_app.h
@@ -39,7 +39,6 @@
  * Necessary to include these here to get the definition of the
  * "SAMPLE_APP_Data_t" typedef.
  */
-#include "sample_app_events.h"
 #include "sample_app.h"
 
 /*


### PR DESCRIPTION
**Describe the contribution**
- Fixes #45
  - Moves the command and utility functions into their own separate source files.

**Testing performed**
GitHub CI actions all passing successfully.

Local testing confirms 100% of cFS suite tests passing (incl. Sample App tests) and coverage unaffected.

Prior to changes:
![Screenshot 2023-04-17 09 23 08](https://user-images.githubusercontent.com/9024662/232349151-649d4772-8610-49ff-8e98-a922aeb75b77.png)

After changes:
![Screenshot 2023-04-17 09 23 47](https://user-images.githubusercontent.com/9024662/232349147-26f0e1c9-a48c-4f6a-a948-a955b302897c.png)

**Expected behavior changes**
No change to behavior.
The Sample App now more closely matches the recommended structure/style for cFS apps.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt