### PR TITLE
Fix #217, Convert remaining `int32` CFE status variables to `CFE_Status_t`

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -44,7 +44,7 @@ SAMPLE_APP_Data_t SAMPLE_APP_Data;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * *  * * * * **/
 void SAMPLE_APP_Main(void)
 {
-    int32            status;
+    CFE_Status_t     status;
     CFE_SB_Buffer_t *SBBufPtr;
 
     /*
@@ -107,10 +107,10 @@ void SAMPLE_APP_Main(void)
 /* Initialization                                                             */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-int32 SAMPLE_APP_Init(void)
+CFE_Status_t SAMPLE_APP_Init(void)
 {
-    int32 status;
-    char VersionString[SAMPLE_APP_CFG_MAX_VERSION_STR_LEN];
+    CFE_Status_t status;
+    char         VersionString[SAMPLE_APP_CFG_MAX_VERSION_STR_LEN];
 
     /* Zero out the global data structure */
     memset(&SAMPLE_APP_Data, 0, sizeof(SAMPLE_APP_Data));
@@ -173,7 +173,6 @@ int32 SAMPLE_APP_Init(void)
         {
             CFE_ES_WriteToSysLog("Sample App: Error Subscribing to Command, RC = 0x%08lX\n", (unsigned long)status);
         }
-
     }
 
     if (status == CFE_SUCCESS)
@@ -192,8 +191,8 @@ int32 SAMPLE_APP_Init(void)
             status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_TABLE_FILE);
         }
 
-        CFE_Config_GetVersionString(VersionString, SAMPLE_APP_CFG_MAX_VERSION_STR_LEN, "Sample App",
-                          SAMPLE_APP_VERSION, SAMPLE_APP_BUILD_CODENAME, SAMPLE_APP_LAST_OFFICIAL);
+        CFE_Config_GetVersionString(VersionString, SAMPLE_APP_CFG_MAX_VERSION_STR_LEN, "Sample App", SAMPLE_APP_VERSION,
+                                    SAMPLE_APP_BUILD_CODENAME, SAMPLE_APP_LAST_OFFICIAL);
 
         CFE_EVS_SendEvent(SAMPLE_APP_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "Sample App Initialized.%s",
                           VersionString);

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -89,7 +89,7 @@ extern SAMPLE_APP_Data_t SAMPLE_APP_Data;
 ** Note: Except for the entry point (SAMPLE_APP_Main), these
 **       functions are not called from any other source module.
 */
-void  SAMPLE_APP_Main(void);
-int32 SAMPLE_APP_Init(void);
+void         SAMPLE_APP_Main(void);
+CFE_Status_t SAMPLE_APP_Init(void);
 
 #endif /* SAMPLE_APP_H */

--- a/fsw/src/sample_app_cmds.c
+++ b/fsw/src/sample_app_cmds.c
@@ -111,7 +111,7 @@ CFE_Status_t SAMPLE_APP_ResetCountersCmd(const SAMPLE_APP_ResetCountersCmd_t *Ms
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
 CFE_Status_t SAMPLE_APP_ProcessCmd(const SAMPLE_APP_ProcessCmd_t *Msg)
 {
-    int32                      status;
+    CFE_Status_t               status;
     void *                     TblAddr;
     SAMPLE_APP_ExampleTable_t *TblPtr;
     const char *               TableName = "SAMPLE_APP.ExampleTable";

--- a/fsw/src/sample_app_utils.c
+++ b/fsw/src/sample_app_utils.c
@@ -34,9 +34,9 @@
 /* Verify contents of First Example Table buffer contents                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_APP_TblValidationFunc(void *TblData)
+CFE_Status_t SAMPLE_APP_TblValidationFunc(void *TblData)
 {
-    int32                      ReturnCode = CFE_SUCCESS;
+    CFE_Status_t               ReturnCode = CFE_SUCCESS;
     SAMPLE_APP_ExampleTable_t *TblDataPtr = (SAMPLE_APP_ExampleTable_t *)TblData;
 
     /*
@@ -58,7 +58,7 @@ int32 SAMPLE_APP_TblValidationFunc(void *TblData)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void SAMPLE_APP_GetCrc(const char *TableName)
 {
-    int32          status;
+    CFE_Status_t   status;
     uint32         Crc;
     CFE_TBL_Info_t TblInfoPtr;
 

--- a/fsw/src/sample_app_utils.h
+++ b/fsw/src/sample_app_utils.h
@@ -29,7 +29,7 @@
 */
 #include "sample_app.h"
 
-int32 SAMPLE_APP_TblValidationFunc(void *TblData);
-void  SAMPLE_APP_GetCrc(const char *TableName);
+CFE_Status_t SAMPLE_APP_TblValidationFunc(void *TblData);
+void         SAMPLE_APP_GetCrc(const char *TableName);
 
 #endif /* SAMPLE_APP_UTILS_H */

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -143,7 +143,7 @@ void Test_SAMPLE_APP_Init(void)
 {
     /*
      * Test Case For:
-     * int32 SAMPLE_APP_Init( void )
+     * CFE_Status_t SAMPLE_APP_Init( void )
      */
 
     /* nominal case should return CFE_SUCCESS */

--- a/unit-test/coveragetest/coveragetest_sample_app_utils.c
+++ b/unit-test/coveragetest/coveragetest_sample_app_utils.c
@@ -48,7 +48,7 @@ void Test_SAMPLE_APP_TblValidationFunc(void)
 {
     /*
      * Test Case For:
-     * int32 SAMPLE_APP_TblValidationFunc( void *TblData )
+     * CFE_Status_t SAMPLE_APP_TblValidationFunc( void *TblData )
      */
     SAMPLE_APP_ExampleTable_t TestTblData;
 

--- a/unit-test/stubs/sample_app_stubs.c
+++ b/unit-test/stubs/sample_app_stubs.c
@@ -30,13 +30,13 @@
  * Generated stub function for SAMPLE_APP_Init()
  * ----------------------------------------------------
  */
-int32 SAMPLE_APP_Init(void)
+CFE_Status_t SAMPLE_APP_Init(void)
 {
-    UT_GenStub_SetupReturnBuffer(SAMPLE_APP_Init, int32);
+    UT_GenStub_SetupReturnBuffer(SAMPLE_APP_Init, CFE_Status_t);
 
     UT_GenStub_Execute(SAMPLE_APP_Init, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SAMPLE_APP_Init, int32);
+    return UT_GenStub_GetReturnValue(SAMPLE_APP_Init, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/sample_app_utils_stubs.c
+++ b/unit-test/stubs/sample_app_utils_stubs.c
@@ -42,13 +42,13 @@ void SAMPLE_APP_GetCrc(const char *TableName)
  * Generated stub function for SAMPLE_APP_TblValidationFunc()
  * ----------------------------------------------------
  */
-int32 SAMPLE_APP_TblValidationFunc(void *TblData)
+CFE_Status_t SAMPLE_APP_TblValidationFunc(void *TblData)
 {
-    UT_GenStub_SetupReturnBuffer(SAMPLE_APP_TblValidationFunc, int32);
+    UT_GenStub_SetupReturnBuffer(SAMPLE_APP_TblValidationFunc, CFE_Status_t);
 
     UT_GenStub_AddParam(SAMPLE_APP_TblValidationFunc, void *, TblData);
 
     UT_GenStub_Execute(SAMPLE_APP_TblValidationFunc, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(SAMPLE_APP_TblValidationFunc, int32);
+    return UT_GenStub_GetReturnValue(SAMPLE_APP_TblValidationFunc, CFE_Status_t);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Minor change
- Fixes #217
  - `int32` variables which hold CFE statuses converted to the more expressive `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt