### PR TITLE
Fix #206, updating sample_app to use new versioning system.

### DIFF
--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -110,6 +110,7 @@ void SAMPLE_APP_Main(void)
 int32 SAMPLE_APP_Init(void)
 {
     int32 status;
+    char VersionString[SAMPLE_APP_CFG_MAX_VERSION_STR_LEN];
 
     /* Zero out the global data structure */
     memset(&SAMPLE_APP_Data, 0, sizeof(SAMPLE_APP_Data));
@@ -191,8 +192,11 @@ int32 SAMPLE_APP_Init(void)
             status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_TABLE_FILE);
         }
 
+        CFE_Config_GetVersionString(VersionString, SAMPLE_APP_CFG_MAX_VERSION_STR_LEN, "Sample App",
+                          SAMPLE_APP_VERSION, SAMPLE_APP_BUILD_CODENAME, SAMPLE_APP_LAST_OFFICIAL);
+
         CFE_EVS_SendEvent(SAMPLE_APP_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "Sample App Initialized.%s",
-                          SAMPLE_APP_VERSION_STRING);
+                          VersionString);
     }
 
     return status;

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -29,6 +29,7 @@
 ** Required header files.
 */
 #include "cfe.h"
+#include "cfe_config.h"
 
 #include "sample_app_mission_cfg.h"
 #include "sample_app_platform_cfg.h"

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -27,16 +27,22 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_APP_BUILD_NUMBER 69 /*!< Development Build: Number of commits since baseline */
-#define SAMPLE_APP_BUILD_BASELINE \
-    "v1.3.0-rc4" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_APP_BUILD_NUMBER    69 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_APP_BUILD_BASELINE  "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_APP_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define SAMPLE_APP_BUILD_CODENAME  "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define SAMPLE_APP_MAJOR_VERSION 1  /*!< @brief Major version number. */
 #define SAMPLE_APP_MINOR_VERSION 1  /*!< @brief Minor version number. */
-#define SAMPLE_APP_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define SAMPLE_APP_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define SAMPLE_APP_LAST_OFFICIAL "v1.1.0"
 
 /*!
  * @brief Mission revision.
@@ -57,12 +63,12 @@
  */
 #define SAMPLE_APP_VERSION SAMPLE_APP_BUILD_BASELINE "+dev" SAMPLE_APP_STR(SAMPLE_APP_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that an OSAL version string can be.
+ * 
  */
-#define SAMPLE_APP_VERSION_STRING                       \
-    " Sample App DEVELOPMENT BUILD " SAMPLE_APP_VERSION \
-    ", Last Official Release: v1.1.0" /* For full support please use this version */
+#define SAMPLE_APP_CFG_MAX_VERSION_STR_LEN 256
 
 #endif /* SAMPLE_APP_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Fixes #206.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "SAMPLE_APP_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC