### PR TITLE
Fix #232, Address sanitizer issue

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_app_cmds.c
+++ b/unit-test/coveragetest/coveragetest_sample_app_cmds.c
@@ -177,6 +177,7 @@ void Test_SAMPLE_APP_ProcessCmd(void)
      * reporting the table values, and one through the CFE_TBL_ReleaseAddress()
      * error path.
      */
+    UT_SetDataBuffer(UT_KEY(CFE_TBL_GetAddress), &TblPtr, sizeof(TblPtr), false);
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_ReleaseAddress), CFE_TBL_ERR_NO_ACCESS);
     UtAssert_INT32_EQ(SAMPLE_APP_ProcessCmd(&TestMsg), CFE_TBL_ERR_NO_ACCESS);


### PR DESCRIPTION
Fix #232, set data buffer for CFE_TBL_GetAddress

**Describe the contribution**
A clear and concise description of what the contribution is.
Fix #232, Update coverage test for address sanitizer issue. 

**Testing performed**
Steps taken to test the contribution:
Add in the following options, then run unit test. 
a. add_compile_options(-fsanitize=address -g)
b. add_link_options(-fsanitize=address)

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES II
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Ind_CLA_form_1219.pdf)
Anh Van, GSFC
