### PR TITLE
Open Source Draco Release

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -2,14 +2,21 @@ name: CodeQl Analysis
 
 on:
   push:
+    branches:
+      - dev
+      - main
   pull_request:
-  
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
 
 jobs:
   codeql:
     name: Codeql Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: apps/sample_app
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/sample_app'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,11 +2,13 @@ name: Format Check
 
 # Run on all push and pull requests
 on:
-  push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,15 @@ name: Static Analysis
 # Run on all push and pull requests
 on:
   push:
+    branches:
+      - dev
+      - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
 
 jobs:
   static-analysis:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(APP_SRC_FILES
   fsw/src/sample_app_utils.c
 )
 
-if (CFE_EDS_ENABLED_BUILD)
+if (CFE_EDS_ENABLED)
   list(APPEND APP_SRC_FILES
     fsw/src/sample_app_eds_dispatch.c
   )

--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -10,24 +10,12 @@
 
 # The list of header files that control the SAMPLE_APP configuration
 set(SAMPLE_APP_PLATFORM_CONFIG_FILE_LIST
-  sample_app_internal_cfg.h
+  sample_app_internal_cfg_values.h
   sample_app_platform_cfg.h
   sample_app_perfids.h
   sample_app_msgids.h
+  sample_app_msgid_values.h
 )
 
-# Create wrappers around the all the config header files
-# This makes them individually overridable by the missions, without modifying
-# the distribution default copies
-foreach(SAMPLE_APP_CFGFILE ${SAMPLE_APP_PLATFORM_CONFIG_FILE_LIST})
-  get_filename_component(CFGKEY "${SAMPLE_APP_CFGFILE}" NAME_WE)
-  if (DEFINED SAMPLE_APP_CFGFILE_SRC_${CFGKEY})
-    set(DEFAULT_SOURCE GENERATED_FILE "${SAMPLE_APP_CFGFILE_SRC_${CFGKEY}}")
-  else()
-    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${SAMPLE_APP_CFGFILE}")
-  endif()
-  generate_config_includefile(
-    FILE_NAME           "${SAMPLE_APP_CFGFILE}"
-    ${DEFAULT_SOURCE}
-  )
-endforeach()
+generate_configfile_set(${SAMPLE_APP_PLATFORM_CONFIG_FILE_LIST})
+

--- a/config/default_sample_app_fcncode_values.h
+++ b/config/default_sample_app_fcncode_values.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -18,26 +18,28 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command function codes
+ *   Specification for the CFE Executive Services (CFE_ES) command function codes
  *
  * @note
  *   This file should be strictly limited to the command/function code (CC)
  *   macro definitions.  Other definitions such as enums, typedefs, or other
  *   macros should be placed in the msgdefs.h or msg.h files.
  */
-#ifndef SAMPLE_APP_FCNCODES_H
-#define SAMPLE_APP_FCNCODES_H
+#ifndef DEFAULT_SAMPLE_APP_FCNCODE_VALUES_H
+#define DEFAULT_SAMPLE_APP_FCNCODE_VALUES_H
 
 /************************************************************************
  * Macro Definitions
  ************************************************************************/
 
-/*
-** Sample App command codes
-*/
-#define SAMPLE_APP_NOOP_CC           0
-#define SAMPLE_APP_RESET_COUNTERS_CC 1
-#define SAMPLE_APP_PROCESS_CC        2
-#define SAMPLE_APP_DISPLAY_PARAM_CC  3
+#define SAMPLE_APP_CCVAL(x) SAMPLE_APP_FunctionCode_##x
+
+enum SAMPLE_APP_FunctionCode_
+{
+    SAMPLE_APP_FunctionCode_NOOP           = 0,
+    SAMPLE_APP_FunctionCode_RESET_COUNTERS = 1,
+    SAMPLE_APP_FunctionCode_PROCESS        = 2,
+    SAMPLE_APP_FunctionCode_DISPLAY_PARAM  = 3,
+};
 
 #endif

--- a/config/default_sample_app_interface_cfg_values.h
+++ b/config/default_sample_app_interface_cfg_values.h
@@ -18,21 +18,21 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
+ *   SAMPLE_APP Application Public Definitions
  *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
+ * This provides default values for configurable items that affect
+ * the interface(s) of this module.  This includes the CMD/TLM message
+ * interface, tables definitions, and any other data products that
+ * serve to exchange information with other entities.
  *
- * @note This file may be overridden/superceded by mission-provided definitions
+ * @note This file may be overridden/superceded by mission-provided definitionsm
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef DEFAULT_SAMPLE_APP_INTERFACE_CFG_H
+#define DEFAULT_SAMPLE_APP_INTERFACE_CFG_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+/* Use the default configuration value for all */
+#define SAMPLE_APP_MISSION_CFGVAL(x) DEFAULT_SAMPLE_APP_MISSION_##x
 
 #endif

--- a/config/default_sample_app_internal_cfg_values.h
+++ b/config/default_sample_app_internal_cfg_values.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -25,21 +25,14 @@
  * to items in this file only affect the local module and will be transparent
  * to external entities that are using the public interface(s).
  *
- * @note This file may be overridden/superceded by mission-provided defintions
+ * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef SAMPLE_APP_INTERNAL_CFG_H
-#define SAMPLE_APP_INTERNAL_CFG_H
+#ifndef DEFAULT_SAMPLE_APP_INTERNAL_CFG_H
+#define DEFAULT_SAMPLE_APP_INTERNAL_CFG_H
 
-/***********************************************************************/
-#define SAMPLE_APP_PIPE_DEPTH 32 /* Depth of the Command Pipe for Application */
-#define SAMPLE_APP_PIPE_NAME  "SAMPLE_APP_CMD_PIPE"
-
-#define SAMPLE_APP_NUMBER_OF_TABLES 1 /* Number of Example Table(s) */
-
-#define SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE -1
-
-#define SAMPLE_APP_TBL_ELEMENT_1_MAX 10
+/* Use the default configuration value for all */
+#define SAMPLE_APP_PLATFORM_CFGVAL(x) DEFAULT_SAMPLE_APP_PLATFORM_##x
 
 #endif

--- a/config/default_sample_app_mission_cfg.h
+++ b/config/default_sample_app_mission_cfg.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -24,12 +24,12 @@
  * This is a compatibility header for the "mission_cfg.h" file that has
  * traditionally provided public config definitions for each CFS app.
  *
- * @note This file may be overridden/superceded by mission-provided defintions
+ * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef SAMPLE_APP_MISSION_CFG_H
-#define SAMPLE_APP_MISSION_CFG_H
+#ifndef DEFAULT_SAMPLE_APP_MISSION_CFG_H
+#define DEFAULT_SAMPLE_APP_MISSION_CFG_H
 
 #include "sample_app_interface_cfg.h"
 

--- a/config/default_sample_app_msgdefs.h
+++ b/config/default_sample_app_msgdefs.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -19,21 +19,19 @@
 /**
  * @file
  *   Specification for the SAMPLE_APP command and telemetry
- *   message constant definitions.
- *
- *  For SAMPLE_APP this is only the function/command code definitions
+ *   message payload and constant definitions.
  */
-#ifndef SAMPLE_APP_MSGDEFS_H
-#define SAMPLE_APP_MSGDEFS_H
+#ifndef DEFAULT_SAMPLE_APP_MSGDEFS_H
+#define DEFAULT_SAMPLE_APP_MSGDEFS_H
 
 #include "common_types.h"
 #include "sample_app_fcncodes.h"
 
 typedef struct SAMPLE_APP_DisplayParam_Payload
 {
-    uint32 ValU32;                            /**< 32 bit unsigned integer value */
-    int16  ValI16;                            /**< 16 bit signed integer value */
-    char   ValStr[SAMPLE_APP_STRING_VAL_LEN]; /**< An example string */
+    uint32 ValU32;                                    /**< 32 bit unsigned integer value */
+    int16  ValI16;                                    /**< 16 bit signed integer value */
+    char   ValStr[SAMPLE_APP_MISSION_STRING_VAL_LEN]; /**< An example string */
 } SAMPLE_APP_DisplayParam_Payload_t;
 
 /*************************************************************************/
@@ -43,8 +41,8 @@ typedef struct SAMPLE_APP_DisplayParam_Payload
 
 typedef struct SAMPLE_APP_HkTlm_Payload
 {
-    uint8 CommandErrorCounter;
     uint8 CommandCounter;
+    uint8 CommandErrorCounter;
     uint8 spare[2];
 } SAMPLE_APP_HkTlm_Payload_t;
 

--- a/config/default_sample_app_msgid_values.h
+++ b/config/default_sample_app_msgid_values.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -20,11 +20,13 @@
  * @file
  *   SAMPLE_APP Application Topic IDs
  */
-#ifndef SAMPLE_APP_TOPICIDS_H
-#define SAMPLE_APP_TOPICIDS_H
+#ifndef DEFAULT_SAMPLE_APP_MSGID_VALUES_H
+#define DEFAULT_SAMPLE_APP_MSGID_VALUES_H
 
-#define CFE_MISSION_SAMPLE_APP_CMD_TOPICID       0x82
-#define CFE_MISSION_SAMPLE_APP_SEND_HK_TOPICID   0x83
-#define CFE_MISSION_SAMPLE_APP_HK_TLM_TOPICID    0x83
+#include "cfe_core_api_base_msgids.h"
+#include "sample_app_topicids.h"
+
+#define SAMPLE_APP_CMD_PLATFORM_MIDVAL(x) CFE_PLATFORM_CMD_TOPICID_TO_MIDV(SAMPLE_APP_MISSION_##x##_TOPICID)
+#define SAMPLE_APP_TLM_PLATFORM_MIDVAL(x) CFE_PLATFORM_TLM_TOPICID_TO_MIDV(SAMPLE_APP_MISSION_##x##_TOPICID)
 
 #endif

--- a/config/default_sample_app_msgids.h
+++ b/config/default_sample_app_msgids.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -20,14 +20,14 @@
  * @file
  *   SAMPLE_APP Application Message IDs
  */
-#ifndef SAMPLE_APP_MSGIDS_H
-#define SAMPLE_APP_MSGIDS_H
+#ifndef DEFAULT_SAMPLE_APP_MSGIDS_H
+#define DEFAULT_SAMPLE_APP_MSGIDS_H
 
 #include "cfe_core_api_base_msgids.h"
-#include "sample_app_topicids.h"
+#include "sample_app_msgid_values.h"
 
-#define SAMPLE_APP_CMD_MID     CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CFE_MISSION_SAMPLE_APP_CMD_TOPICID)
-#define SAMPLE_APP_SEND_HK_MID CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CFE_MISSION_SAMPLE_APP_SEND_HK_TOPICID)
-#define SAMPLE_APP_HK_TLM_MID  CFE_PLATFORM_TLM_TOPICID_TO_MIDV(CFE_MISSION_SAMPLE_APP_HK_TLM_TOPICID)
+#define SAMPLE_APP_CMD_MID     SAMPLE_APP_CMD_PLATFORM_MIDVAL(CMD)
+#define SAMPLE_APP_SEND_HK_MID SAMPLE_APP_CMD_PLATFORM_MIDVAL(SEND_HK)
+#define SAMPLE_APP_HK_TLM_MID  SAMPLE_APP_TLM_PLATFORM_MIDVAL(HK_TLM)
 
 #endif

--- a/config/default_sample_app_msgstruct.h
+++ b/config/default_sample_app_msgstruct.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -25,8 +25,8 @@
  *   Constants and enumerated types related to these message structures
  *   are defined in sample_app_msgdefs.h.
  */
-#ifndef SAMPLE_APP_MSGSTRUCT_H
-#define SAMPLE_APP_MSGSTRUCT_H
+#ifndef DEFAULT_SAMPLE_APP_MSGSTRUCT_H
+#define DEFAULT_SAMPLE_APP_MSGSTRUCT_H
 
 /************************************************************************
  * Includes

--- a/config/default_sample_app_perfids.h
+++ b/config/default_sample_app_perfids.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/config/default_sample_app_tbl.h
+++ b/config/default_sample_app_tbl.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -24,13 +24,10 @@
  *   Constants and enumerated types related to these table structures
  *   are defined in sample_app_tbldefs.h.
  */
-#ifndef SAMPLE_APP_TBL_H
-#define SAMPLE_APP_TBL_H
+#ifndef DEFAULT_SAMPLE_APP_TBL_H
+#define DEFAULT_SAMPLE_APP_TBL_H
 
 #include "sample_app_tbldefs.h"
 #include "sample_app_tblstruct.h"
-
-/* Define filenames of default data images for tables */
-#define SAMPLE_APP_TABLE_FILE "/cf/sample_app_tbl.tbl"
 
 #endif

--- a/config/default_sample_app_tbldefs.h
+++ b/config/default_sample_app_tbldefs.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -20,12 +20,6 @@
  * @file
  *   Specification for the SAMPLE_APP table related
  *   constant definitions.
- *
- * @note
- *   These Macro definitions have been put in this file (instead of
- *   sample_app_tbl.h). DO NOT PUT ANY TYPEDEFS OR
- *   STRUCTURE DEFINITIONS IN THIS FILE!
- *   ADD THEM TO sample_app_tbl.h IF NEEDED!
  */
 #ifndef SAMPLE_APP_TBLDEFS_H
 #define SAMPLE_APP_TBLDEFS_H

--- a/config/default_sample_app_tblstruct.h
+++ b/config/default_sample_app_tblstruct.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -22,7 +22,7 @@
  *
  * Provides default definitions for SAMPLE_APP table structures
  *
- * @note This file may be overridden/superceded by mission-provided defintions
+ * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */

--- a/config/default_sample_app_topicid_values.h
+++ b/config/default_sample_app_topicid_values.h
@@ -18,21 +18,11 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
- *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ *   Specification for the SAMPLE_APP topic ID values
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef DEFAULT_SAMPLE_APP_TOPICID_VALUES_H
+#define DEFAULT_SAMPLE_APP_TOPICID_VALUES_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#define SAMPLE_APP_MISSION_TIDVAL(x) DEFAULT_SAMPLE_APP_MISSION_##x##_TOPICID
 
 #endif

--- a/config/eds_sample_app_fcncode_values.h
+++ b/config/eds_sample_app_fcncode_values.h
@@ -18,21 +18,22 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
+ *   Specification for the CFE Executive Services (SAMPLE_APP) command function codes
  *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ * @note
+ *   This file should be strictly limited to the command/function code (CC)
+ *   macro definitions.  Other definitions such as enums, typedefs, or other
+ *   macros should be placed in the msgdefs.h or msg.h files.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef EDS_SAMPLE_APP_FCNCODES_H
+#define EDS_SAMPLE_APP_FCNCODES_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "sample_app_eds_cc.h"
+
+/************************************************************************
+ * Macro Definitions
+ ************************************************************************/
+
+#define SAMPLE_APP_CCVAL(x) EDS_CONTAINER_SAMPLE_APP_##x##_CC
 
 #endif

--- a/config/eds_sample_app_interface_cfg_values.h
+++ b/config/eds_sample_app_interface_cfg_values.h
@@ -18,21 +18,22 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
+ *   SAMPLE_APP Application Public Definitions
  *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
+ * This provides default values for configurable items that affect
+ * the interface(s) of this module.  This includes the CMD/TLM message
+ * interface, tables definitions, and any other data products that
+ * serve to exchange information with other entities.
  *
  * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef EDS_SAMPLE_APP_INTERFACE_CFG_H
+#define EDS_SAMPLE_APP_INTERFACE_CFG_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "cfe_mission_eds_designparameters.h"
+
+#define CFE_MISSION_ES_CFGVAL(x) EdsParam_CFE_MISSION_ES_##x
 
 #endif

--- a/config/eds_sample_app_msgdefs.h
+++ b/config/eds_sample_app_msgdefs.h
@@ -19,20 +19,12 @@
 /**
  * @file
  *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
- *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ *   message payload and constant definitions.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef EDS_SAMPLE_APP_MSGDEFS_H
+#define EDS_SAMPLE_APP_MSGDEFS_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "sample_app_eds_typedefs.h"
+#include "sample_app_fcncodes.h"
 
 #endif

--- a/config/eds_sample_app_msgstruct.h
+++ b/config/eds_sample_app_msgstruct.h
@@ -20,19 +20,13 @@
  * @file
  *   Specification for the SAMPLE_APP command and telemetry
  *   message data types.
- *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef EDS_SAMPLE_APP_MSGSTRUCT_H
+#define EDS_SAMPLE_APP_MSGSTRUCT_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+/************************************************************************
+ * Includes
+ ************************************************************************/
+#include "sample_app_eds_typedefs.h"
 
 #endif

--- a/config/eds_sample_app_tbldefs.h
+++ b/config/eds_sample_app_tbldefs.h
@@ -18,21 +18,12 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
- *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ *   Specification for the SAMPLE_APP table related
+ *   constant definitions.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef EDS_SAMPLE_APP_TBLDEFS_H
+#define EDS_SAMPLE_APP_TBLDEFS_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "sample_app_eds_typedefs.h"
 
 #endif

--- a/config/eds_sample_app_topicid_values.h
+++ b/config/eds_sample_app_topicid_values.h
@@ -18,21 +18,13 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
- *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ *   Specification for the SAMPLE_APP topic ID values
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef EDS_SAMPLE_APP_TOPICIDS_H
+#define EDS_SAMPLE_APP_TOPICIDS_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "cfe_mission_eds_designparameters.h"
+
+#define SAMPLE_APP_MISSION_TIDVAL(x) EdsParam_CFE_MISSION_SAMPLE_APP_##x##_TOPICID
 
 #endif

--- a/eds/sample_app.xml
+++ b/eds/sample_app.xml
@@ -103,6 +103,11 @@
     <ComponentSet>
       <Component name="Application">
         <RequiredInterfaceSet>
+          <Interface name="ExampleTable" shortDescription="Table interface" type="CFE_TBL/Table">
+            <GenericTypeMapSet>
+              <GenericTypeMap name="TableDataType" type="ExampleTable" />
+            </GenericTypeMapSet>
+          </Interface>
           <Interface name="CMD" shortDescription="Software bus telecommand interface" type="CFE_SB/Telecommand">
             <GenericTypeMapSet>
               <GenericTypeMap name="TelecommandDataType" type="CommandBase" />

--- a/fsw/inc/sample_app_eventids.h
+++ b/fsw/inc/sample_app_eventids.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/fsw/inc/sample_app_fcncodes.h
+++ b/fsw/inc/sample_app_fcncodes.h
@@ -18,21 +18,28 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
+ *   Specification for the SAMPLE_APP command function codes
  *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ * @note
+ *   This file should be strictly limited to the command/function code (CC)
+ *   macro definitions.  Other definitions such as enums, typedefs, or other
+ *   macros should be placed in the msgdefs.h or msg.h files.
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef SAMPLE_APP_FCNCODES_H
+#define SAMPLE_APP_FCNCODES_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "sample_app_fcncode_values.h"
+
+/************************************************************************
+ * Macro Definitions
+ ************************************************************************/
+
+/*
+** Sample App command codes
+*/
+#define SAMPLE_APP_NOOP_CC           SAMPLE_APP_CCVAL(NOOP)
+#define SAMPLE_APP_RESET_COUNTERS_CC SAMPLE_APP_CCVAL(RESET_COUNTERS)
+#define SAMPLE_APP_PROCESS_CC        SAMPLE_APP_CCVAL(PROCESS)
+#define SAMPLE_APP_DISPLAY_PARAM_CC  SAMPLE_APP_CCVAL(DISPLAY_PARAM)
 
 #endif

--- a/fsw/inc/sample_app_interface_cfg.h
+++ b/fsw/inc/sample_app_interface_cfg.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -18,19 +18,20 @@
 
 /**
  * @file
- *   SAMPLE_APP Application Public Definitions
  *
- * This provides default values for configurable items that affect
- * the interface(s) of this module.  This includes the CMD/TLM message
- * interface, tables definitions, and any other data products that
- * serve to exchange information with other entities.
+ * SAMPLE_APP Application Mission Configuration Header File
  *
- * @note This file may be overridden/superceded by mission-provided defintions
+ * This is a compatibility header for the "mission_cfg.h" file that has
+ * traditionally provided public config definitions for each CFS app.
+ *
+ * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
 #ifndef SAMPLE_APP_INTERFACE_CFG_H
 #define SAMPLE_APP_INTERFACE_CFG_H
+
+#include "sample_app_interface_cfg_values.h"
 
 /**
  * \brief Length of string buffer in the Display Value command
@@ -39,6 +40,7 @@
  * parameters of different types.  This macro controls the length
  * of the string parameter.
  */
-#define SAMPLE_APP_STRING_VAL_LEN 10
+#define SAMPLE_APP_MISSION_STRING_VAL_LEN         SAMPLE_APP_MISSION_CFGVAL(STRING_VAL_LEN)
+#define DEFAULT_SAMPLE_APP_MISSION_STRING_VAL_LEN 10
 
 #endif

--- a/fsw/inc/sample_app_internal_cfg.h
+++ b/fsw/inc/sample_app_internal_cfg.h
@@ -32,10 +32,28 @@
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SAMPLE_APP_PLATFORM_CFG_H
-#define DEFAULT_SAMPLE_APP_PLATFORM_CFG_H
+#ifndef SAMPLE_APP_INTERNAL_CFG_H
+#define SAMPLE_APP_INTERNAL_CFG_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_internal_cfg.h"
+#include "sample_app_internal_cfg_values.h"
+
+/***********************************************************************/
+#define SAMPLE_APP_PLATFORM_PIPE_DEPTH         SAMPLE_APP_PLATFORM_CFGVAL(PIPE_DEPTH)
+#define DEFAULT_SAMPLE_APP_PLATFORM_PIPE_DEPTH 32 /* Depth of the Command Pipe for Application */
+
+#define SAMPLE_APP_PLATFORM_PIPE_NAME         SAMPLE_APP_PLATFORM_CFGVAL(PIPE_NAME)
+#define DEFAULT_SAMPLE_APP_PLATFORM_PIPE_NAME "SAMPLE_APP_CMD_PIPE"
+
+#define SAMPLE_APP_PLATFORM_NUMBER_OF_TABLES         SAMPLE_APP_PLATFORM_CFGVAL(NUMBER_OF_TABLES)
+#define DEFAULT_SAMPLE_APP_PLATFORM_NUMBER_OF_TABLES 1 /* Number of Example Table(s) */
+
+#define SAMPLE_APP_PLATFORM_TABLE_OUT_OF_RANGE_ERR_CODE         SAMPLE_APP_PLATFORM_CFGVAL(TABLE_OUT_OF_RANGE_ERR_CODE)
+#define DEFAULT_SAMPLE_APP_PLATFORM_TABLE_OUT_OF_RANGE_ERR_CODE -1
+
+#define SAMPLE_APP_PLATFORM_TBL_ELEMENT_1_MAX         SAMPLE_APP_PLATFORM_CFGVAL(TBL_ELEMENT_1_MAX)
+#define DEFAULT_SAMPLE_APP_PLATFORM_TBL_ELEMENT_1_MAX 10
+
+#define SAMPLE_APP_PLATFORM_TABLE_FILE         SAMPLE_APP_PLATFORM_CFGVAL(TABLE_FILE)
+#define DEFAULT_SAMPLE_APP_PLATFORM_TABLE_FILE "/cf/sample_app_tbl.tbl"
 
 #endif

--- a/fsw/inc/sample_app_topicids.h
+++ b/fsw/inc/sample_app_topicids.h
@@ -18,21 +18,18 @@
 
 /**
  * @file
- *   Specification for the SAMPLE_APP command and telemetry
- *   message data types.
- *
- * This is a compatibility header for the "sample_app_msg.h" file that has
- * traditionally provided the message definitions for cFS apps.
- *
- * @note This file may be overridden/superceded by mission-provided definitions
- * either by overriding this header or by generating definitions from a command/data
- * dictionary tool.
+ *   SAMPLE_APP Application Topic IDs
  */
-#ifndef DEFAULT_SAMPLE_APP_MSG_H
-#define DEFAULT_SAMPLE_APP_MSG_H
+#ifndef SAMPLE_APP_TOPICIDS_H
+#define SAMPLE_APP_TOPICIDS_H
 
-#include "sample_app_mission_cfg.h"
-#include "sample_app_msgdefs.h"
-#include "sample_app_msgstruct.h"
+#include "sample_app_topicid_values.h"
+
+#define SAMPLE_APP_MISSION_CMD_TOPICID             SAMPLE_APP_MISSION_TIDVAL(CMD)
+#define DEFAULT_SAMPLE_APP_MISSION_CMD_TOPICID     0x82
+#define SAMPLE_APP_MISSION_SEND_HK_TOPICID         SAMPLE_APP_MISSION_TIDVAL(SEND_HK)
+#define DEFAULT_SAMPLE_APP_MISSION_SEND_HK_TOPICID 0x83
+#define SAMPLE_APP_MISSION_HK_TLM_TOPICID          SAMPLE_APP_MISSION_TIDVAL(HK_TLM)
+#define DEFAULT_SAMPLE_APP_MISSION_HK_TLM_TOPICID  0x83
 
 #endif

--- a/fsw/src/sample_app.c
+++ b/fsw/src/sample_app.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -136,7 +136,8 @@ CFE_Status_t SAMPLE_APP_Init(void)
         /*
          ** Create Software Bus message pipe.
          */
-        status = CFE_SB_CreatePipe(&SAMPLE_APP_Data.CommandPipe, SAMPLE_APP_PIPE_DEPTH, SAMPLE_APP_PIPE_NAME);
+        status = CFE_SB_CreatePipe(&SAMPLE_APP_Data.CommandPipe, SAMPLE_APP_PLATFORM_PIPE_DEPTH,
+                                   SAMPLE_APP_PLATFORM_PIPE_NAME);
         if (status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(SAMPLE_APP_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -184,7 +185,7 @@ CFE_Status_t SAMPLE_APP_Init(void)
         }
         else
         {
-            status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_TABLE_FILE);
+            status = CFE_TBL_Load(SAMPLE_APP_Data.TblHandles[0], CFE_TBL_SRC_FILE, SAMPLE_APP_PLATFORM_TABLE_FILE);
         }
 
         CFE_Config_GetVersionString(VersionString, SAMPLE_APP_CFG_MAX_VERSION_STR_LEN, "Sample App", SAMPLE_APP_VERSION,

--- a/fsw/src/sample_app.h
+++ b/fsw/src/sample_app.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -68,7 +68,7 @@ typedef struct
     */
     CFE_SB_PipeId_t CommandPipe;
 
-    CFE_TBL_Handle_t TblHandles[SAMPLE_APP_NUMBER_OF_TABLES];
+    CFE_TBL_Handle_t TblHandles[SAMPLE_APP_PLATFORM_NUMBER_OF_TABLES];
 } SAMPLE_APP_Data_t;
 
 /*

--- a/fsw/src/sample_app_cmds.c
+++ b/fsw/src/sample_app_cmds.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -63,7 +63,7 @@ CFE_Status_t SAMPLE_APP_SendHkCmd(const SAMPLE_APP_SendHkCmd_t *Msg)
     /*
     ** Manage any pending table loads, validations, etc.
     */
-    for (i = 0; i < SAMPLE_APP_NUMBER_OF_TABLES; i++)
+    for (i = 0; i < SAMPLE_APP_PLATFORM_NUMBER_OF_TABLES; i++)
     {
         CFE_TBL_Manage(SAMPLE_APP_Data.TblHandles[i]);
     }

--- a/fsw/src/sample_app_cmds.h
+++ b/fsw/src/sample_app_cmds.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/fsw/src/sample_app_dispatch.h
+++ b/fsw/src/sample_app_dispatch.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/fsw/src/sample_app_eds_dispatch.c
+++ b/fsw/src/sample_app_eds_dispatch.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -37,12 +37,22 @@
 /*
  * Define a lookup table for SAMPLE app command codes
  */
-static const EdsDispatchTable_SAMPLE_APP_Application_CFE_SB_Telecommand_t SAMPLE_TC_DISPATCH_TABLE = {
-    .CMD     = {.NoopCmd_indication          = SAMPLE_APP_NoopCmd,
-            .ResetCountersCmd_indication = SAMPLE_APP_ResetCountersCmd,
-            .ProcessCmd_indication       = SAMPLE_APP_ProcessCmd,
-            .DisplayParamCmd_indication  = SAMPLE_APP_DisplayParamCmd},
-    .SEND_HK = {.indication = SAMPLE_APP_SendHkCmd}};
+/* clang-format off */
+static const EdsDispatchTable_EdsComponent_SAMPLE_APP_Application_CFE_SB_Telecommand_t SAMPLE_TC_DISPATCH_TABLE = 
+{
+    .CMD =
+    {
+        .NoopCmd_indication          = SAMPLE_APP_NoopCmd,
+        .ResetCountersCmd_indication = SAMPLE_APP_ResetCountersCmd,
+        .ProcessCmd_indication       = SAMPLE_APP_ProcessCmd,
+        .DisplayParamCmd_indication  = SAMPLE_APP_DisplayParamCmd
+    },
+    .SEND_HK =
+    {
+        .indication = SAMPLE_APP_SendHkCmd
+    }
+};
+/* clang-format on */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
@@ -58,7 +68,7 @@ void SAMPLE_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
     CFE_MSG_Size_t    MsgSize;
     CFE_MSG_FcnCode_t MsgFc;
 
-    Status = EdsDispatch_SAMPLE_APP_Application_Telecommand(SBBufPtr, &SAMPLE_TC_DISPATCH_TABLE);
+    Status = EdsDispatch_EdsComponent_SAMPLE_APP_Application_Telecommand(SBBufPtr, &SAMPLE_TC_DISPATCH_TABLE);
 
     if (Status != CFE_SUCCESS)
     {

--- a/fsw/src/sample_app_utils.c
+++ b/fsw/src/sample_app_utils.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -42,10 +42,10 @@ CFE_Status_t SAMPLE_APP_TblValidationFunc(void *TblData)
     /*
     ** Sample Example Table Validation
     */
-    if (TblDataPtr->Int1 > SAMPLE_APP_TBL_ELEMENT_1_MAX)
+    if (TblDataPtr->Int1 > SAMPLE_APP_PLATFORM_TBL_ELEMENT_1_MAX)
     {
         /* First element is out of range, return an appropriate error code */
-        ReturnCode = SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE;
+        ReturnCode = SAMPLE_APP_PLATFORM_TABLE_OUT_OF_RANGE_ERR_CODE;
     }
 
     return ReturnCode;

--- a/fsw/src/sample_app_utils.h
+++ b/fsw/src/sample_app_utils.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/fsw/src/sample_app_version.h
+++ b/fsw/src/sample_app_version.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -27,22 +27,22 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_APP_BUILD_NUMBER    54
-#define SAMPLE_APP_BUILD_BASELINE  "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
-#define SAMPLE_APP_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define SAMPLE_APP_BUILD_CODENAME  "Equuleus" /**< @brief: Development: Code name for the current build */
+#define SAMPLE_APP_BUILD_NUMBER    0
+#define SAMPLE_APP_BUILD_BASELINE  "v7.0.0" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_APP_BUILD_DEV_CYCLE "v7.0.0" /**< @brief Development: Release name for current development cycle */
+#define SAMPLE_APP_BUILD_CODENAME  "Draco" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
-#define SAMPLE_APP_MAJOR_VERSION 1  /*!< @brief Major version number. */
-#define SAMPLE_APP_MINOR_VERSION 1  /*!< @brief Minor version number. */
+#define SAMPLE_APP_MAJOR_VERSION 7  /*!< @brief Major version number. */
+#define SAMPLE_APP_MINOR_VERSION 0  /*!< @brief Minor version number. */
 #define SAMPLE_APP_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
 
 /**
  * @brief Last official release.
  */
-#define SAMPLE_APP_LAST_OFFICIAL "v1.1.0"
+#define SAMPLE_APP_LAST_OFFICIAL "v7.0.0"
 
 /*!
  * @brief Mission revision.
@@ -51,7 +51,7 @@
  * Values 1-254 are reserved for mission use to denote patches/customizations as needed. NOTE: Reserving 0 and 0xFF for
  * cFS open-source development use (pending resolution of nasa/cFS#440)
  */
-#define SAMPLE_APP_MISSION_REV 0xFF
+#define SAMPLE_APP_MISSION_REV 0x0
 
 #define SAMPLE_APP_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
 #define SAMPLE_APP_STR(x) \

--- a/fsw/tables/sample_app_tbl.c
+++ b/fsw/tables/sample_app_tbl.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -10,8 +10,8 @@
 
 # The list of header files that control the SAMPLE_APP configuration
 set(SAMPLE_APP_MISSION_CONFIG_FILE_LIST
-  sample_app_fcncodes.h
-  sample_app_interface_cfg.h
+  sample_app_fcncode_values.h
+  sample_app_interface_cfg_values.h
   sample_app_mission_cfg.h
   sample_app_perfids.h
   sample_app_msg.h
@@ -20,33 +20,8 @@ set(SAMPLE_APP_MISSION_CONFIG_FILE_LIST
   sample_app_tbl.h
   sample_app_tbldefs.h
   sample_app_tblstruct.h
-  sample_app_topicids.h
+  sample_app_topicid_values.h
 )
 
-if (CFE_EDS_ENABLED_BUILD)
+generate_configfile_set(${SAMPLE_APP_MISSION_CONFIG_FILE_LIST})
 
-  # In an EDS-based build, these files come generated from the EDS tool
-  set(SAMPLE_APP_CFGFILE_SRC_sample_app_interface_cfg "sample_app_eds_designparameters.h")
-  set(SAMPLE_APP_CFGFILE_SRC_sample_app_tbldefs       "sample_app_eds_typedefs.h")
-  set(SAMPLE_APP_CFGFILE_SRC_sample_app_tblstruct     "sample_app_eds_typedefs.h")
-  set(SAMPLE_APP_CFGFILE_SRC_sample_app_msgdefs       "sample_app_eds_typedefs.h")
-  set(SAMPLE_APP_CFGFILE_SRC_sample_app_msgstruct     "sample_app_eds_typedefs.h")
-  set(SAMPLE_APP_CFGFILE_SRC_sample_app_fcncodes      "sample_app_eds_cc.h")
-
-endif(CFE_EDS_ENABLED_BUILD)
-
-# Create wrappers around the all the config header files
-# This makes them individually overridable by the missions, without modifying
-# the distribution default copies
-foreach(SAMPLE_APP_CFGFILE ${SAMPLE_APP_MISSION_CONFIG_FILE_LIST})
-  get_filename_component(CFGKEY "${SAMPLE_APP_CFGFILE}" NAME_WE)
-  if (DEFINED SAMPLE_APP_CFGFILE_SRC_${CFGKEY})
-    set(DEFAULT_SOURCE GENERATED_FILE "${SAMPLE_APP_CFGFILE_SRC_${CFGKEY}}")
-  else()
-    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${SAMPLE_APP_CFGFILE}")
-  endif()
-  generate_config_includefile(
-    FILE_NAME           "${SAMPLE_APP_CFGFILE}"
-    ${DEFAULT_SOURCE}
-  )
-endforeach()

--- a/unit-test/common/eventcheck.c
+++ b/unit-test/common/eventcheck.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/common/eventcheck.h
+++ b/unit-test/common/eventcheck.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/common/setup.c
+++ b/unit-test/common/setup.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/common/setup.h
+++ b/unit-test/common/setup.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/coveragetest/coveragetest_sample_app.c
+++ b/unit-test/coveragetest/coveragetest_sample_app.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/coveragetest/coveragetest_sample_app_cmds.c
+++ b/unit-test/coveragetest/coveragetest_sample_app_cmds.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/coveragetest/coveragetest_sample_app_dispatch.c
+++ b/unit-test/coveragetest/coveragetest_sample_app_dispatch.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/coveragetest/coveragetest_sample_app_eds_dispatch.c
+++ b/unit-test/coveragetest/coveragetest_sample_app_eds_dispatch.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/coveragetest/coveragetest_sample_app_utils.c
+++ b/unit-test/coveragetest/coveragetest_sample_app_utils.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -57,9 +57,9 @@ void Test_SAMPLE_APP_TblValidationFunc(void)
     /* nominal case (0) should succeed */
     UtAssert_INT32_EQ(SAMPLE_APP_TblValidationFunc(&TestTblData), CFE_SUCCESS);
 
-    /* error case should return SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE */
-    TestTblData.Int1 = 1 + SAMPLE_APP_TBL_ELEMENT_1_MAX;
-    UtAssert_INT32_EQ(SAMPLE_APP_TblValidationFunc(&TestTblData), SAMPLE_APP_TABLE_OUT_OF_RANGE_ERR_CODE);
+    /* error case should return SAMPLE_APP_PLATFORM_TABLE_OUT_OF_RANGE_ERR_CODE */
+    TestTblData.Int1 = 1 + SAMPLE_APP_PLATFORM_TBL_ELEMENT_1_MAX;
+    UtAssert_INT32_EQ(SAMPLE_APP_TblValidationFunc(&TestTblData), SAMPLE_APP_PLATFORM_TABLE_OUT_OF_RANGE_ERR_CODE);
 }
 
 void Test_SAMPLE_APP_GetCrc(void)

--- a/unit-test/coveragetest/sample_app_coveragetest_common.h
+++ b/unit-test/coveragetest/sample_app_coveragetest_common.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/stubs/sample_app_cmds_stubs.c
+++ b/unit-test/stubs/sample_app_cmds_stubs.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/stubs/sample_app_dispatch_stubs.c
+++ b/unit-test/stubs/sample_app_dispatch_stubs.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/stubs/sample_app_global_stubs.c
+++ b/unit-test/stubs/sample_app_global_stubs.c
@@ -1,8 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
- * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2021 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/stubs/sample_app_stubs.c
+++ b/unit-test/stubs/sample_app_stubs.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/unit-test/stubs/sample_app_utils_stubs.c
+++ b/unit-test/stubs/sample_app_utils_stubs.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *


### PR DESCRIPTION
[NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"](https://github.com/nasa/sample_app/pull/242/commits/c37cedad019f1344d314b02c6c883d089a6a0994)
Batch update of latest cFS software release

Reflects commit 71681c4ed98d9a0cb32284bcce4cb97105c60988 from NASA internal development repo