### PR TITLE
Fix #255, Releasing table address prior to issuing a table manage command

### DIFF
--- a/fsw/src/sample_app_cmds.c
+++ b/fsw/src/sample_app_cmds.c
@@ -65,6 +65,7 @@ CFE_Status_t SAMPLE_APP_SendHkCmd(const SAMPLE_APP_SendHkCmd_t *Msg)
     */
     for (i = 0; i < SAMPLE_APP_PLATFORM_NUMBER_OF_TABLES; i++)
     {
+        CFE_TBL_ReleaseAddress(SAMPLE_APP_Data.TblHandles[i]);
         CFE_TBL_Manage(SAMPLE_APP_Data.TblHandles[i]);
     }
 


### PR DESCRIPTION
Releasing table address prior to issuing a table manage command in the SAMPLE_APP_SendHkCmd() function.

**Describe the contribution**
See https://github.com/nasa/sample_app/issues/255

**Testing performed**
Steps taken to test the contribution:
1. Standard build steps
1. Standard execution steps

**Expected behavior changes**
 - Behavior Change: Lock file associated with the table address is set to false

**System(s) tested on**
 - N/A

**Additional context**
See https://github.com/nasa/sample_app/issues/255

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
- GSFC Contractor on SES III
  - david.t.herceg@nasa.gov, MCSG Technologies Inc, SES III - Task 2007
